### PR TITLE
Changing the ZMQClient __state to REQ when the system detects a synta…

### DIFF
--- a/zmq/include/zapata/zmq/config.h
+++ b/zmq/include/zapata/zmq/config.h
@@ -76,7 +76,7 @@
 #define PACKAGE_NAME "zapata-zmq"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "zapata-zmq 0.9.7-1yakkety49"
+#define PACKAGE_STRING "zapata-zmq 0.9.7-1yakkety50"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "zapata-zmq"
@@ -85,10 +85,10 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "0.9.7-1yakkety49"
+#define PACKAGE_VERSION "0.9.7-1yakkety50"
 
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
 
 /* Version number of package */
-#define VERSION "0.9.7-1yakkety49"
+#define VERSION "0.9.7-1yakkety50"

--- a/zmq/m4/libtool.m4
+++ b/zmq/m4/libtool.m4
@@ -728,6 +728,7 @@ _LT_CONFIG_SAVE_COMMANDS([
     cat <<_LT_EOF >> "$cfgfile"
 #! $SHELL
 # Generated automatically by $as_me ($PACKAGE) $VERSION
+# Libtool was configured on host `(hostname || uname -n) 2>/dev/null | sed 1q`:
 # NOTE: Changes made to this file will be lost: look at ltmain.sh.
 
 # Provide generalized library-building support services.

--- a/zmq/src/zmq/ZMQClient.cpp
+++ b/zmq/src/zmq/ZMQClient.cpp
@@ -1619,6 +1619,7 @@ auto zpt::ZMQHttp::recv() -> zpt::json {
 	}
 	catch(zpt::SyntaxErrorException& _e) {
 		zlog(std::string("error while parsing HTTP request: syntax error exception"), zpt::error);
+		this->__state = HTTP_REQ;
 		return { "protocol", this->protocol(), "status", 400, "payload", { "text", _e.what(), "assertion_failed", _e.what(), "code", 1062 } };
 	}
 	_in << "protocol" << this->protocol();


### PR DESCRIPTION
…x error to send the error to the ::send function without change the logic of assertz validating performative and state of each request by socket.

Please check it this change makes sense. In my local tests this change works fine. Thank you.