### PR TITLE
Fixing problem with boolean fields in the search by params in CouchDB module

### DIFF
--- a/base/m4/libtool.m4
+++ b/base/m4/libtool.m4
@@ -728,6 +728,7 @@ _LT_CONFIG_SAVE_COMMANDS([
     cat <<_LT_EOF >> "$cfgfile"
 #! $SHELL
 # Generated automatically by $as_me ($PACKAGE) $VERSION
+# Libtool was configured on host `(hostname || uname -n) 2>/dev/null | sed 1q`:
 # NOTE: Changes made to this file will be lost: look at ltmain.sh.
 
 # Provide generalized library-building support services.

--- a/couchdb/m4/libtool.m4
+++ b/couchdb/m4/libtool.m4
@@ -728,6 +728,7 @@ _LT_CONFIG_SAVE_COMMANDS([
     cat <<_LT_EOF >> "$cfgfile"
 #! $SHELL
 # Generated automatically by $as_me ($PACKAGE) $VERSION
+# Libtool was configured on host `(hostname || uname -n) 2>/dev/null | sed 1q`:
 # NOTE: Changes made to this file will be lost: look at ltmain.sh.
 
 # Provide generalized library-building support services.

--- a/couchdb/src/couchdb/convert_couchdb.cpp
+++ b/couchdb/src/couchdb/convert_couchdb.cpp
@@ -142,11 +142,11 @@ auto zpt::couchdb::get_query(zpt::json _in) -> zpt::json {
 						if (!iss.eof()) {
 							std::string bexpr(_expression.data());
 							std::transform(bexpr.begin(), bexpr.end(), bexpr.begin(), ::tolower);
-							if (bexpr != "true" && bexpr != "false") {
+							if (bexpr != std::string("true") && bexpr != std::string("false")) {
 								_selector << std::string(_key) << _expression;
 							}
 							else {
-								_selector << std::string(_key) << bexpr == "true";
+								_selector << std::string(_key) << zpt::json::boolean(bexpr == std::string("true"));
 							}
 						}
 						else {
@@ -200,11 +200,11 @@ auto zpt::couchdb::get_query(zpt::json _in) -> zpt::json {
 							if (!iss.eof()) {
 								std::string bexpr(_expression.data());
 								std::transform(bexpr.begin(), bexpr.end(), bexpr.begin(), ::tolower);
-								if (bexpr != "true" && bexpr != "false") {
+								if (bexpr != std::string("true") && bexpr != std::string("false")) {
 									_selector << std::string(_key) << zpt::json{ comp, _expression };
 								}
 								else {
-									_selector << std::string(_key) << zpt::json{ comp, (bexpr == "true") };
+									_selector << std::string(_key) << zpt::json{ comp, zpt::json::boolean(bexpr == std::string("true")) };
 								}
 							}
 							else {
@@ -233,7 +233,12 @@ auto zpt::couchdb::get_query(zpt::json _in) -> zpt::json {
 			}
 		}
 
-		_selector << std::string(_key) << _value;
+		if (_value->ok() && _value->is_string() && (_value->str() == std::string("true") || _value->str() == std::string("false"))) {
+			_selector << std::string(_key) << zpt::json::boolean(_value->str() == std::string("true"));
+		} else {
+			_selector << std::string(_key) << _value;
+		}
+
 	}
 
 	if (!_query["limit"]->ok()) {

--- a/events/m4/libtool.m4
+++ b/events/m4/libtool.m4
@@ -728,6 +728,7 @@ _LT_CONFIG_SAVE_COMMANDS([
     cat <<_LT_EOF >> "$cfgfile"
 #! $SHELL
 # Generated automatically by $as_me ($PACKAGE) $VERSION
+# Libtool was configured on host `(hostname || uname -n) 2>/dev/null | sed 1q`:
 # NOTE: Changes made to this file will be lost: look at ltmain.sh.
 
 # Provide generalized library-building support services.

--- a/http/m4/libtool.m4
+++ b/http/m4/libtool.m4
@@ -728,6 +728,7 @@ _LT_CONFIG_SAVE_COMMANDS([
     cat <<_LT_EOF >> "$cfgfile"
 #! $SHELL
 # Generated automatically by $as_me ($PACKAGE) $VERSION
+# Libtool was configured on host `(hostname || uname -n) 2>/dev/null | sed 1q`:
 # NOTE: Changes made to this file will be lost: look at ltmain.sh.
 
 # Provide generalized library-building support services.

--- a/json/m4/libtool.m4
+++ b/json/m4/libtool.m4
@@ -728,6 +728,7 @@ _LT_CONFIG_SAVE_COMMANDS([
     cat <<_LT_EOF >> "$cfgfile"
 #! $SHELL
 # Generated automatically by $as_me ($PACKAGE) $VERSION
+# Libtool was configured on host `(hostname || uname -n) 2>/dev/null | sed 1q`:
 # NOTE: Changes made to this file will be lost: look at ltmain.sh.
 
 # Provide generalized library-building support services.

--- a/lisp/m4/libtool.m4
+++ b/lisp/m4/libtool.m4
@@ -728,6 +728,7 @@ _LT_CONFIG_SAVE_COMMANDS([
     cat <<_LT_EOF >> "$cfgfile"
 #! $SHELL
 # Generated automatically by $as_me ($PACKAGE) $VERSION
+# Libtool was configured on host `(hostname || uname -n) 2>/dev/null | sed 1q`:
 # NOTE: Changes made to this file will be lost: look at ltmain.sh.
 
 # Provide generalized library-building support services.

--- a/mqtt/m4/libtool.m4
+++ b/mqtt/m4/libtool.m4
@@ -728,6 +728,7 @@ _LT_CONFIG_SAVE_COMMANDS([
     cat <<_LT_EOF >> "$cfgfile"
 #! $SHELL
 # Generated automatically by $as_me ($PACKAGE) $VERSION
+# Libtool was configured on host `(hostname || uname -n) 2>/dev/null | sed 1q`:
 # NOTE: Changes made to this file will be lost: look at ltmain.sh.
 
 # Provide generalized library-building support services.

--- a/oauth2/m4/libtool.m4
+++ b/oauth2/m4/libtool.m4
@@ -728,6 +728,7 @@ _LT_CONFIG_SAVE_COMMANDS([
     cat <<_LT_EOF >> "$cfgfile"
 #! $SHELL
 # Generated automatically by $as_me ($PACKAGE) $VERSION
+# Libtool was configured on host `(hostname || uname -n) 2>/dev/null | sed 1q`:
 # NOTE: Changes made to this file will be lost: look at ltmain.sh.
 
 # Provide generalized library-building support services.

--- a/python/m4/libtool.m4
+++ b/python/m4/libtool.m4
@@ -728,6 +728,7 @@ _LT_CONFIG_SAVE_COMMANDS([
     cat <<_LT_EOF >> "$cfgfile"
 #! $SHELL
 # Generated automatically by $as_me ($PACKAGE) $VERSION
+# Libtool was configured on host `(hostname || uname -n) 2>/dev/null | sed 1q`:
 # NOTE: Changes made to this file will be lost: look at ltmain.sh.
 
 # Provide generalized library-building support services.

--- a/redis/m4/libtool.m4
+++ b/redis/m4/libtool.m4
@@ -728,6 +728,7 @@ _LT_CONFIG_SAVE_COMMANDS([
     cat <<_LT_EOF >> "$cfgfile"
 #! $SHELL
 # Generated automatically by $as_me ($PACKAGE) $VERSION
+# Libtool was configured on host `(hostname || uname -n) 2>/dev/null | sed 1q`:
 # NOTE: Changes made to this file will be lost: look at ltmain.sh.
 
 # Provide generalized library-building support services.

--- a/rest/include/zapata/rest/config.h
+++ b/rest/include/zapata/rest/config.h
@@ -49,7 +49,7 @@
 #define HAVE_LIBZAPATA_PYTHON 1
 
 /* Define to 1 if you have the `zapata-upnp' library (-lzapata-upnp). */
-#define HAVE_LIBZAPATA_UPNP 1
+/* #undef HAVE_LIBZAPATA_UPNP */
 
 /* Define to 1 if you have the `zapata-zmq' library (-lzapata-zmq). */
 #define HAVE_LIBZAPATA_ZMQ 1

--- a/rest/m4/libtool.m4
+++ b/rest/m4/libtool.m4
@@ -728,6 +728,7 @@ _LT_CONFIG_SAVE_COMMANDS([
     cat <<_LT_EOF >> "$cfgfile"
 #! $SHELL
 # Generated automatically by $as_me ($PACKAGE) $VERSION
+# Libtool was configured on host `(hostname || uname -n) 2>/dev/null | sed 1q`:
 # NOTE: Changes made to this file will be lost: look at ltmain.sh.
 
 # Provide generalized library-building support services.

--- a/zmq/m4/libtool.m4
+++ b/zmq/m4/libtool.m4
@@ -728,6 +728,7 @@ _LT_CONFIG_SAVE_COMMANDS([
     cat <<_LT_EOF >> "$cfgfile"
 #! $SHELL
 # Generated automatically by $as_me ($PACKAGE) $VERSION
+# Libtool was configured on host `(hostname || uname -n) 2>/dev/null | sed 1q`:
 # NOTE: Changes made to this file will be lost: look at ltmain.sh.
 
 # Provide generalized library-building support services.


### PR DESCRIPTION
This fix converts the boolean params in zpt::json::boolean to keep the type right to send to the CouchDB as native javascript boolean and fix some std::string == char* comparations to detect if it is a boolean field.