### PR TITLE
Fixing the problem to convert UUIDs

### DIFF
--- a/python/src/zapata/rest/__init__.py
+++ b/python/src/zapata/rest/__init__.py
@@ -265,6 +265,8 @@ class RestHandler(object):
 
         if type(_object) in [int, list]:
             return _object
+        elif type(_object) in [str]:
+            return '"{}"'.format(_object)
         else:
             return '"{}"'.format(re.escape(_object))
 


### PR DESCRIPTION
 Fixing the problem to convert UUIDs that have '-' and became '\-' after the re.escape method when it is a simple string object