### PR TITLE
Fixing the shell command to return all files

### DIFF
--- a/rest/etc/default/zapata.rc
+++ b/rest/etc/default/zapata.rc
@@ -6,7 +6,8 @@ fi
 
 ZAPATA_ENV_CWD=${BASH_SOURCE%/*}
 
-for rc_file in `find /etc/zapata/rc.d/ -name "*.rc"`
+rcs=$(find /etc/zapata/rc.d/ -name "*.rc")
+for rc_file in $rcs
 do
 	[ -f ${rc_file} ] && source ${rc_file}
 done

--- a/rest/etc/default/zapata.rc
+++ b/rest/etc/default/zapata.rc
@@ -1,13 +1,12 @@
-
 RUNNING_SHELL=$(readlink /proc/$$/exe)
 if [[ $RUNNING_SHELL == /bin/zsh* ]]
 then
 	BASH_SOURCE=${(%):-%x}
 fi
+
 ZAPATA_ENV_CWD=${BASH_SOURCE%/*}
 
-rcs=($(find /etc/zapata/rc.d/ -name "*.rc"))
-for rc_file in $rcs
+for rc_file in `find /etc/zapata/rc.d/ -name "*.rc"`
 do
 	[ -f ${rc_file} ] && source ${rc_file}
 done


### PR DESCRIPTION
Loading Environment variables in more than one file is not working
We have the environment files in /etc/zapata/rc.d/*.rc to be loaded, and when there is more than one file it is not loading all files.

