### PR TITLE
Zapata 1.0.0 issue 100

### DIFF
--- a/rest/src/rest/RESTEmitter.cpp
+++ b/rest/src/rest/RESTEmitter.cpp
@@ -262,12 +262,18 @@ auto zpt::RESTEmitter::has_pending(zpt::json _envelope) -> bool {
 auto zpt::RESTEmitter::reply(zpt::json _request, zpt::json _reply) -> void {
 	auto _exists = this->__pending.find(std::string(_request["channel"]));
 	if (_exists != this->__pending.end()) {
+		auto _callback = _exists->second;
+		this->__pending.erase(_exists);
 		if (_reply->ok()) {
-			auto _callback = _exists->second;
-			this->__pending.erase(_exists);
-			_callback(zpt::ev::Reply, std::string(_request["resource"]), _reply, this->self());
+			try {
+				_callback(zpt::ev::Reply, std::string(_request["resource"]), _reply, this->self());
+			} catch(zpt::assertion& _e) {
+				_callback(zpt::ev::Reply, std::string(_request["resource"]), { "status", _e.status(), "payload", { "text", _e.what(), "assertion_failed", _e.description(), "code", _e.code() } }, this->self());
+			} catch(std::exception& _e) {
+				_callback(zpt::ev::Reply, std::string(_request["resource"]), { "status", 500, "payload", { "text", _e.what(), "code", 0 } }, this->self());
+			}
 		} else {
-			this->__pending.erase(_exists);
+			_callback(zpt::ev::Reply, std::string(_request["resource"]), { "status", 408, "payload", { "text", "No response object available for this request", "code", 0 } }, this->self());
 		}
 	}
 }

--- a/rest/src/rest/RESTEmitter.cpp
+++ b/rest/src/rest/RESTEmitter.cpp
@@ -265,13 +265,7 @@ auto zpt::RESTEmitter::reply(zpt::json _request, zpt::json _reply) -> void {
 		auto _callback = _exists->second;
 		this->__pending.erase(_exists);
 		if (_reply->ok()) {
-			try {
-				_callback(zpt::ev::Reply, std::string(_request["resource"]), _reply, this->self());
-			} catch(zpt::assertion& _e) {
-				_callback(zpt::ev::Reply, std::string(_request["resource"]), { "status", _e.status(), "payload", { "text", _e.what(), "assertion_failed", _e.description(), "code", _e.code() } }, this->self());
-			} catch(std::exception& _e) {
-				_callback(zpt::ev::Reply, std::string(_request["resource"]), { "status", 500, "payload", { "text", _e.what(), "code", 0 } }, this->self());
-			}
+            _callback(zpt::ev::Reply, std::string(_request["resource"]), _reply, this->self());
 		} else {
 			_callback(zpt::ev::Reply, std::string(_request["resource"]), { "status", 408, "payload", { "text", "No response object available for this request", "code", 0 } }, this->self());
 		}


### PR DESCRIPTION
 Adding protection in the zpt::RESTEmitter::reply to reply to the callback to not let the loop stuck due to an invalid reply