### PR TITLE
Use `sqlite3_open_v2` to bootstrap databases

### DIFF
--- a/engines/rest/src/test.cpp
+++ b/engines/rest/src/test.cpp
@@ -37,10 +37,11 @@ class test_plugin_collection : public zpt::events::process {
 
     auto operator()(zpt::events::dispatcher::ptr _dispatcher [[maybe_unused]])
       -> zpt::events::state {
+        zlog("Received plugin collection request: " << this->received()->body(), zpt::info);
         this
           ->to_send() //
           ->status(200)
-          .body() = { "something", "something" };
+          .body() = { "echo", this->received()->body() };
         return zpt::events::finish;
     }
 };
@@ -72,7 +73,7 @@ extern "C" auto _zpt_load_(zpt::plugin&) -> void {
     _test_message //
       ->performative(zpt::Post)
       .uri(std::format("{}/test_plugin", _prefix))
-      .body() = { "test", "something" };
+      .body() = { "from", "self", "date", zpt::json::date(), "id", zpt::generate::r_uuid() };
 
     zpt::TRANSPORT_ENGINE() //
       .dispatcher()

--- a/engines/rest/src/test_client.conf
+++ b/engines/rest/src/test_client.conf
@@ -1,0 +1,32 @@
+{
+    "identity": {
+        "id": "3ca77f4d-4e6c-44ff-b151-3d86c0a9f495",
+        "name": "rest-client"
+    },
+    "log": { "level": 7, "format": 1 },
+    "load": [
+        { "name": "builtin:http" },
+        { "name": "builtin:tcp" },
+        { "name": "builtin:upnp" },
+        { "name": "builtin:rest" },
+        { "name": "rest-client", "source": "libzapata-rest-client-example.so", "requires": [ "builtin:rest" ] }
+    ],
+    "dispatcher": {
+        "limits": {
+            "max_consumer_threads": 0,
+            "max_memory": 1048576
+        }
+    },
+    "tcp": { "bind": "${any}", "port": 8083 },
+    "http": { "bind": "${any}", "port": 8082 },
+    "upnp": { "bind": "239.192.1.2", "port": 7979 },
+    "transport": {
+        "default": "tcp",
+        "limits": {
+            "max_consumer_threads": 16
+        }
+    },
+    "rest": {
+        "prefix" : "/api/1.0"
+    }
+}

--- a/engines/rest/src/test_client.cpp
+++ b/engines/rest/src/test_client.cpp
@@ -59,7 +59,9 @@ class test_client_boot : public zpt::system_event {
             _test_message //
               ->performative(zpt::Post)
               .uri(std::format("{}/test_plugin", _prefix))
-              .body() = { "test", "something" };
+              .body() = {
+                "from", "client", "date", zpt::json::date(), "id", zpt::generate::r_uuid()
+            };
 
             zpt::TRANSPORT_ENGINE() //
               .dispatcher()

--- a/engines/rest/src/test_server.conf
+++ b/engines/rest/src/test_server.conf
@@ -1,0 +1,32 @@
+{
+    "identity": {
+        "id": "a4a444e4-a6e0-11f0-99fa-ff740730cd76",
+        "name": "rest-server"
+    },
+    "log": { "level": 7, "format": 1 },
+    "load": [
+        { "name": "builtin:http" },
+        { "name": "builtin:tcp" },
+        { "name": "builtin:upnp" },
+        { "name": "builtin:rest" },
+        { "name": "rest-server", "source": "libzapata-rest-example.so", "requires": [ "builtin:rest" ] }
+    ],
+    "dispatcher": {
+        "limits": {
+            "max_consumer_threads": 0,
+            "max_memory": 1048576
+        }
+    },
+    "tcp": { "bind": "${any}", "port": 8081 },
+    "http": { "bind": "${any}", "port": 8080 },
+    "upnp": { "bind": "239.192.1.2", "port": 7979 },
+    "transport": {
+        "default": "tcp",
+        "limits": {
+            "max_consumer_threads": 16
+        }
+    },
+    "rest": {
+        "prefix" : "/api/1.0"
+    }
+}

--- a/storage/sqlite/src/connector.cpp
+++ b/storage/sqlite/src/connector.cpp
@@ -233,11 +233,15 @@ auto zpt::storage::sqlite::session::add_database_connection(sqlite3_ptr _databas
 
 zpt::storage::sqlite::database::database(zpt::storage::sqlite::session const& _session,
                                          std::string const& _db)
-  : __path{ _session.__options("path")->ok()
-              ? _session.__options("path")->string() + std::string{ "/" } + _db
-              : std::string{ "file:" } + _db + std::string{ "?mode=memory&cache=shared" } } {
+  : __path{ std::string{ "file:" } +
+            (_session.__options("path")->ok()
+               ? _session.__options("path")->string() + std::string{ "/" } + _db
+               : _db + std::string{ "?mode=memory&cache=shared" }) } {
     sqlite3* _underlying{ nullptr };
-    sqlite_expect(sqlite3_open(this->__path.data(), &_underlying),
+    sqlite_expect(sqlite3_open_v2(this->__path.data(),
+                                  &_underlying,
+                                  SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_URI,
+                                  nullptr),
                   "couldn't open database at " << this->__path);
     this->__underlying.reset(_underlying, zpt::storage::sqlite::close_connection{});
     const_cast<zpt::storage::sqlite::session&>(_session).add_database_connection(


### PR DESCRIPTION
The `sqlite3_open` method is reaplced by `sqlite3_open_v2` method and `SQLITE_OPEN_URI` flag is explicitly passed to force URI processing