### PR TITLE
Authorization infra-structure

### DIFF
--- a/common/base/include/zapata/base/expect.h
+++ b/common/base/include/zapata/base/expect.h
@@ -35,13 +35,19 @@
  * validation
  * @param x a boolean expression to be validated
  * @param y the error message
- * @param z the HTTP status code to be replied to the invoking HTTP client
  */
 #define expect(x, y)                                                                               \
     if (!(x)) {                                                                                    \
         std::ostringstream __OSS__;                                                                \
         __OSS__ << y << std::flush;                                                                \
         throw zpt::ExpectationException(__OSS__.str(), #x, __LINE__, __FILE__);                    \
+    }
+
+#define expect_c(x, y, c)                                                                          \
+    if (!(x)) {                                                                                    \
+        std::ostringstream __OSS__;                                                                \
+        __OSS__ << y << std::flush;                                                                \
+        throw zpt::ExpectationException(__OSS__.str(), #x, __LINE__, __FILE__, c);                 \
     }
 
 namespace zpt {

--- a/common/base/include/zapata/exceptions/Exception.h
+++ b/common/base/include/zapata/exceptions/Exception.h
@@ -45,4 +45,8 @@ class exception : public std::exception {
     std::string __what;
 };
 
+class unauthorized_exception : public zpt::exception {
+  public:
+    using zpt::exception::exception;
+};
 } // namespace zpt

--- a/common/base/include/zapata/exceptions/ExpectationException.h
+++ b/common/base/include/zapata/exceptions/ExpectationException.h
@@ -34,10 +34,13 @@ class ExpectationException : public zpt::exception {
     ExpectationException(std::string const& _what,
                          std::string _desc,
                          int _line = 0,
-                         std::string _file = "");
+                         std::string _file = "",
+                         int _code = 500);
     virtual ~ExpectationException() throw();
 
     virtual auto description() const -> const char*;
+
+    virtual auto code() const -> int;
 
     friend auto operator<<(std::ostream& _out, zpt::ExpectationException const& _in)
       -> std::ostream& {
@@ -49,6 +52,7 @@ class ExpectationException : public zpt::exception {
     std::string __description;
     int __line;
     std::string __file;
+    int __code;
 };
 
 using failed_expectation = ExpectationException;

--- a/common/base/src/ExpectationException.cpp
+++ b/common/base/src/ExpectationException.cpp
@@ -27,11 +27,13 @@
 zpt::ExpectationException::ExpectationException(std::string const& _what,
                                                 std::string _desc,
                                                 int _line,
-                                                std::string _file)
+                                                std::string _file,
+                                                int _code)
   : zpt::exception{ std::format("{} ({}:{})", _what, _file, _line) }
   , __description(_desc)
   , __line(_line)
-  , __file(_file) {
+  , __file(_file)
+  , __code{ _code } {
     zpt::replace(this->__description, "\"", "");
     this->__description.insert(0, "expected `");
     if (this->__line != 0) {
@@ -47,3 +49,5 @@ zpt::ExpectationException::~ExpectationException() throw() {}
 auto zpt::ExpectationException::description() const -> const char* {
     return this->__description.data();
 }
+
+auto zpt::ExpectationException::code() const -> int { return this->__code; }

--- a/common/events/include/zapata/events/dispatcher.h
+++ b/common/events/include/zapata/events/dispatcher.h
@@ -75,6 +75,7 @@ concept Operation = requires(T t,
                              zpt::failed_expectation const& _fe) {
     { t.initialize(_i) } -> std::convertible_to<void>;
     { t.blocked() } -> std::convertible_to<bool>;
+    { t.authorized() } -> std::convertible_to<bool>;
     { t.catch_error(_e, _d) } -> std::convertible_to<bool>;
     { t.catch_error(_bae, _d) } -> std::convertible_to<bool>;
     { t.catch_error(_fe, _d) } -> std::convertible_to<bool>;
@@ -89,6 +90,7 @@ class abstract_event {
 
     virtual auto initialize(zpt::event_initialization& init_data) -> void = 0;
     virtual auto blocked() const -> bool = 0;
+    virtual auto authorized() const -> bool = 0;
     virtual auto catch_error(std::exception const& _e, zpt::events::dispatcher::ptr _dispatcher)
       -> bool = 0;
     virtual auto catch_error(std::bad_alloc const& _e, zpt::events::dispatcher::ptr _dispatcher)
@@ -110,6 +112,7 @@ class event_t : public zpt::abstract_event {
     auto operator*() const -> T const&;
     virtual auto initialize(zpt::event_initialization& init_data) -> void override final;
     virtual auto blocked() const -> bool override final;
+    virtual auto authorized() const -> bool override final;
     virtual auto catch_error(std::exception const& _e, zpt::events::dispatcher::ptr _dispatcher)
       -> bool override final;
     virtual auto catch_error(std::bad_alloc const& _e, zpt::events::dispatcher::ptr _dispatcher)
@@ -156,6 +159,11 @@ auto zpt::event_t<T>::initialize(zpt::event_initialization& init_data) -> void {
 template<zpt::events::Operation T>
 auto zpt::event_t<T>::blocked() const -> bool {
     return this->__underlying.blocked();
+}
+
+template<zpt::events::Operation T>
+auto zpt::event_t<T>::authorized() const -> bool {
+    return this->__underlying.authorized();
 }
 
 template<zpt::events::Operation T>

--- a/common/events/include/zapata/events/system_events.h
+++ b/common/events/include/zapata/events/system_events.h
@@ -28,6 +28,7 @@ class system_event {
 
     virtual auto initialize(zpt::event_initialization& _init) -> void final;
     virtual auto blocked() const -> bool;
+    virtual auto authorized() const -> bool;
     virtual auto catch_error(std::exception const& _e, zpt::events::dispatcher::ptr _dispatcher)
       -> bool;
     virtual auto catch_error(std::bad_alloc const& _e, zpt::events::dispatcher::ptr _dispatcher)

--- a/common/events/src/dispatcher.cpp
+++ b/common/events/src/dispatcher.cpp
@@ -79,6 +79,7 @@ auto zpt::events::dispatcher::trap() -> dispatcher& {
 #ifndef PROPAGATE_EXCEPTION
     try {
 #endif
+        expect_c(_event->authorized(), "No permission to process this event", 401);
         auto state = (*_event)(this->shared_from_this());
         if (state == zpt::events::retrigger) { this->trigger(_event); }
 #ifndef PROPAGATE_EXCEPTION

--- a/common/events/src/system_events.cpp
+++ b/common/events/src/system_events.cpp
@@ -20,6 +20,8 @@ auto zpt::system_event::initialize(zpt::event_initialization&) -> void {
 
 auto zpt::system_event::blocked() const -> bool { return false; }
 
+auto zpt::system_event::authorized() const -> bool { return true; }
+
 auto zpt::system_event::catch_error(std::exception const& _e, zpt::events::dispatcher::ptr)
   -> bool {
     zlog(_e.what(), zpt::error);

--- a/common/events/src/test.cpp
+++ b/common/events/src/test.cpp
@@ -30,6 +30,7 @@ class my_operator {
 
     auto initialize(zpt::event_initialization&) -> void {}
     auto blocked() const -> bool { return false; }
+    auto authorized() const -> bool { return true; }
     auto catch_error(std::exception const&, zpt::events::dispatcher::ptr) -> bool { return false; }
     auto catch_error(std::bad_alloc const&, zpt::events::dispatcher::ptr) -> bool { return false; }
     auto catch_error(zpt::failed_expectation const&, zpt::events::dispatcher::ptr) -> bool {
@@ -54,6 +55,7 @@ class my_other_operator {
 
     auto initialize(zpt::event_initialization&) -> void {}
     auto blocked() const -> bool { return false; }
+    auto authorized() const -> bool { return true; }
     auto catch_error(std::exception const&, zpt::events::dispatcher::ptr) -> bool { return false; }
     auto catch_error(std::bad_alloc const&, zpt::events::dispatcher::ptr) -> bool { return false; }
     auto catch_error(zpt::failed_expectation const&, zpt::events::dispatcher::ptr) -> bool {

--- a/engines/transport/include/zapata/transport/engine.h
+++ b/engines/transport/include/zapata/transport/engine.h
@@ -47,6 +47,7 @@ class receive {
 
     auto initialize(zpt::event_initialization& init) -> void;
     auto blocked() const -> bool;
+    auto authorized() const -> bool;
     auto catch_error(std::exception const& _e, zpt::events::dispatcher::ptr _dispatcher) -> bool;
     auto catch_error(std::bad_alloc const& _e, zpt::events::dispatcher::ptr _dispatcher) -> bool;
     auto catch_error(zpt::failed_expectation const& _e, zpt::events::dispatcher::ptr _dispatcher)
@@ -71,6 +72,7 @@ class send {
 
     auto initialize(zpt::event_initialization& init) -> void;
     auto blocked() const -> bool;
+    auto authorized() const -> bool;
     auto catch_error(std::exception const& _e, zpt::events::dispatcher::ptr _dispatcher) -> bool;
     auto catch_error(std::bad_alloc const& _e, zpt::events::dispatcher::ptr _dispatcher) -> bool;
     auto catch_error(zpt::failed_expectation const& _e, zpt::events::dispatcher::ptr _dispatcher)
@@ -103,6 +105,7 @@ class process {
     virtual auto context(zpt::call_context::ptr _context) -> process& final;
 
     virtual auto initialize(zpt::event_initialization& init) -> void final;
+    virtual auto authorized() const -> bool;
     virtual auto catch_error(std::exception const& _e, zpt::events::dispatcher::ptr _dispatcher)
       -> bool final;
     virtual auto catch_error(std::bad_alloc const& _e, zpt::events::dispatcher::ptr _dispatcher)
@@ -153,6 +156,7 @@ class call {
 
     auto initialize(zpt::event_initialization& init) -> void;
     auto blocked() const -> bool;
+    auto authorized() const -> bool;
     auto catch_error(std::exception const& _e, zpt::events::dispatcher::ptr _dispatcher) -> bool;
     auto catch_error(std::bad_alloc const& _e, zpt::events::dispatcher::ptr _dispatcher) -> bool;
     auto catch_error(zpt::failed_expectation const& _e, zpt::events::dispatcher::ptr _dispatcher)
@@ -209,6 +213,11 @@ auto zpt::events::call<T>::initialize(zpt::event_initialization& _init) -> void 
 template<ProcessOperation T>
 auto zpt::events::call<T>::blocked() const -> bool {
     return false;
+}
+
+template<ProcessOperation T>
+auto zpt::events::call<T>::authorized() const -> bool {
+    return true;
 }
 
 template<ProcessOperation T>

--- a/engines/transport/src/engine.cpp
+++ b/engines/transport/src/engine.cpp
@@ -5,7 +5,12 @@
 namespace {
 template<typename T>
 auto get_error_body(T const& _e) -> zpt::json {
-    zpt::json _to_return{ "error", 500, "exception", zpt::demangle(typeid(T).name()) };
+    int _error{500};
+    if constexpr (std::is_same_v<T, zpt::failed_expectation>) {
+        _error = _e.code();
+    }
+    
+    zpt::json _to_return{ "error", _error, "exception", zpt::demangle(typeid(T).name()) };
     if constexpr (std::is_same_v<T, std::bad_alloc>) {
         _to_return["what"] = "Unable to allocate memory outside configure maximum value.";
     }
@@ -30,9 +35,10 @@ auto report_error(T const& _e, zpt::stream _stream, zpt::polling::ptr _polling) 
 
     _stream->state() = zpt::stream_state::ERRORING_OUT;
     auto _reply = _transport->make_reply(false);
+    auto _body = ::get_error_body(_e);
     _reply //
-      ->status(500)
-      .body() = ::get_error_body(_e);
+      ->status(_body("error")->integer())
+      .body() = _body;
     return _reply;
 }
 } // namespace
@@ -49,6 +55,8 @@ zpt::events::receive::~receive() {}
 auto zpt::events::receive::initialize(zpt::event_initialization&) -> void {}
 
 auto zpt::events::receive::blocked() const -> bool { return false; }
+
+auto zpt::events::receive::authorized() const -> bool { return true; }
 
 auto zpt::events::receive::catch_error(std::exception const& _e,
                                        zpt::events::dispatcher::ptr _dispatcher) -> bool {
@@ -139,6 +147,8 @@ auto zpt::events::send::initialize(zpt::event_initialization&) -> void {}
 
 auto zpt::events::send::blocked() const -> bool { return false; }
 
+auto zpt::events::send::authorized() const -> bool { return true; }
+
 auto zpt::events::send::catch_error(std::exception const&, zpt::events::dispatcher::ptr) -> bool {
     return false;
 }
@@ -221,6 +231,8 @@ auto zpt::events::process::initialize(zpt::event_initialization& _init) -> void 
     this->__to_send = _transport->make_reply(this->__received);
     this->__to_send->status(0);
 }
+
+auto zpt::events::process::authorized() const -> bool { return true; }
 
 auto zpt::events::process::catch_error(std::exception const& _e, zpt::events::dispatcher::ptr)
   -> bool {

--- a/generators/rest/src/rest.cpp
+++ b/generators/rest/src/rest.cpp
@@ -289,6 +289,7 @@ auto zpt::gen::rest::unit::generate_collection(zpt::json _def, zpt::json _path)
                                         "",
                                         zpt::ast::DEFAULT)
           .add<zpt::ast::cpp_function>(zpt::ast::PUBLIC, "blocked", "bool", zpt::ast::CONST)
+          .add<zpt::ast::cpp_function>(zpt::ast::PUBLIC, "authorized", "bool", zpt::ast::CONST)
           .add<zpt::ast::cpp_function>(zpt::ast::PUBLIC, "add_element", "zpt::events::state")
           .add<zpt::ast::cpp_function>(zpt::ast::PUBLIC, "list_elements", "zpt::events::state")
           .add<zpt::ast::cpp_function>(zpt::ast::PUBLIC, "remove_elements", "zpt::events::state");
@@ -321,6 +322,13 @@ auto zpt::gen::rest::unit::generate_collection(zpt::json _def, zpt::json _path)
         _cpp_blocked->add(_cpp_blocked_body);
         _cpp_file->add(_cpp_blocked);
 
+        auto _cpp_authorized = zpt::make_function<zpt::ast::cpp_function>(
+          std::format("{}authorized", _class_method_prefix), "bool", zpt::ast::CONST);
+        auto _cpp_authorized_body = zpt::make_code_block<zpt::ast::cpp_code_block>();
+        _cpp_authorized_body->add<zpt::ast::cpp_instruction>("return true");
+        _cpp_authorized->add(_cpp_authorized_body);
+        _cpp_file->add(_cpp_authorized);
+        
         this->generate_add_element(_cpp_file, _def, _path);
         this->generate_list_elements(_cpp_file, _def, _path);
         this->generate_remove_elements(_cpp_file, _def, _path);
@@ -378,6 +386,7 @@ auto zpt::gen::rest::unit::generate_document(zpt::json _def, zpt::json _path)
                                         "",
                                         zpt::ast::DEFAULT)
           .add<zpt::ast::cpp_function>(zpt::ast::PUBLIC, "blocked", "bool", zpt::ast::CONST)
+          .add<zpt::ast::cpp_function>(zpt::ast::PUBLIC, "authorized", "bool", zpt::ast::CONST)
           .add<zpt::ast::cpp_function>(zpt::ast::PUBLIC, "update_element", "zpt::events::state")
           .add<zpt::ast::cpp_function>(zpt::ast::PUBLIC, "get_element", "zpt::events::state")
           .add<zpt::ast::cpp_function>(zpt::ast::PUBLIC, "remove_element", "zpt::events::state");
@@ -415,6 +424,13 @@ auto zpt::gen::rest::unit::generate_document(zpt::json _def, zpt::json _path)
         _cpp_blocked->add(_cpp_blocked_body);
         _cpp_file->add(_cpp_blocked);
 
+        auto _cpp_authorized = zpt::make_function<zpt::ast::cpp_function>(
+          std::format("{}authorized", _class_method_prefix), "bool", zpt::ast::CONST);
+        auto _cpp_authorized_body = zpt::make_code_block<zpt::ast::cpp_code_block>();
+        _cpp_authorized_body->add<zpt::ast::cpp_instruction>("return true");
+        _cpp_authorized->add(_cpp_authorized_body);
+        _cpp_file->add(_cpp_authorized);
+        
         this->generate_update_element(_cpp_file, _def, _path);
         this->generate_get_element(_cpp_file, _def, _path);
         this->generate_remove_element(_cpp_file, _def, _path);
@@ -474,6 +490,7 @@ auto zpt::gen::rest::unit::generate_controller(zpt::json _def, zpt::json _path)
                                         "",
                                         zpt::ast::DEFAULT)
           .add<zpt::ast::cpp_function>(zpt::ast::PUBLIC, "blocked", "bool", zpt::ast::CONST)
+          .add<zpt::ast::cpp_function>(zpt::ast::PUBLIC, "authorized", "bool", zpt::ast::CONST)
           .add<zpt::ast::cpp_function>(zpt::ast::PUBLIC, "process_request", "zpt::events::state");
         _namespace->add(_class);
 
@@ -503,6 +520,13 @@ auto zpt::gen::rest::unit::generate_controller(zpt::json _def, zpt::json _path)
         _cpp_blocked_body->add<zpt::ast::cpp_instruction>("return false");
         _cpp_blocked->add(_cpp_blocked_body);
         _cpp_file->add(_cpp_blocked);
+
+        auto _cpp_authorized = zpt::make_function<zpt::ast::cpp_function>(
+          std::format("{}authorized", _class_method_prefix), "bool", zpt::ast::CONST);
+        auto _cpp_authorized_body = zpt::make_code_block<zpt::ast::cpp_code_block>();
+        _cpp_authorized_body->add<zpt::ast::cpp_instruction>("return true");
+        _cpp_authorized->add(_cpp_authorized_body);
+        _cpp_file->add(_cpp_authorized);
 
         this->generate_process_request(_cpp_file, _def, _path);
 
@@ -551,6 +575,7 @@ auto zpt::gen::rest::unit::generate_store(zpt::json _def, zpt::json _path)
                                         "",
                                         zpt::ast::DEFAULT)
           .add<zpt::ast::cpp_function>(zpt::ast::PUBLIC, "blocked", "bool", zpt::ast::CONST)
+          .add<zpt::ast::cpp_function>(zpt::ast::PUBLIC, "authorized", "bool", zpt::ast::CONST)
           .add<zpt::ast::cpp_function>(zpt::ast::PUBLIC, "add_element", "zpt::events::state")
           .add<zpt::ast::cpp_function>(zpt::ast::PUBLIC, "list_elements", "zpt::events::state")
           .add<zpt::ast::cpp_function>(zpt::ast::PUBLIC, "remove_elements", "zpt::events::state");
@@ -583,6 +608,13 @@ auto zpt::gen::rest::unit::generate_store(zpt::json _def, zpt::json _path)
         _cpp_blocked->add(_cpp_blocked_body);
         _cpp_file->add(_cpp_blocked);
 
+        auto _cpp_authorized = zpt::make_function<zpt::ast::cpp_function>(
+          std::format("{}authorized", _class_method_prefix), "bool", zpt::ast::CONST);
+        auto _cpp_authorized_body = zpt::make_code_block<zpt::ast::cpp_code_block>();
+        _cpp_authorized_body->add<zpt::ast::cpp_instruction>("return true");
+        _cpp_authorized->add(_cpp_authorized_body);
+        _cpp_file->add(_cpp_authorized);
+        
         this->generate_add_element(_cpp_file, _def, _path);
         this->generate_list_elements(_cpp_file, _def, _path);
         this->generate_remove_elements(_cpp_file, _def, _path);

--- a/generators/rest/src/rest.cpp
+++ b/generators/rest/src/rest.cpp
@@ -1085,9 +1085,7 @@ auto zpt::gen::rest::unit::remove_hidden_fields(zpt::json _def) -> std::string {
     if (_def("*")("requestBody")("allOf")->ok()) {
         _oss << "_fields -= zpt::json{ zpt::array";
         for (auto const& [_, __, _type] : _def("*")("requestBody")("allOf")) {
-            for (auto const& [___, ____, _prop] : _type("hidden")) {
-                _oss << ", \"" << _prop << "\"";
-            }
+            for (auto const& [___, ____, _prop] : _type("hidden")) { _oss << ", " << _prop; }
         }
         _oss << " }" << std::flush;
     }

--- a/parsers/json/src/JSONPtr.cpp
+++ b/parsers/json/src/JSONPtr.cpp
@@ -523,7 +523,13 @@ auto zpt::json::operator-=(zpt::json _rhs) -> zpt::json& {
             return (*this);
         }
         case zpt::JSArray: {
-            for (auto [_idx, _, __] : _rhs) { (**this).array()->pop(_idx); }
+            std::vector<size_t> _to_remove;
+            for (auto [__, _, _remove] : _rhs) {
+                for (auto [_idx, ____, _value] : (*this)) {
+                    if (_value == _remove) { _to_remove.push_back(_idx); }
+                }
+            }
+            for (auto _idx : _to_remove) { (**this).array()->pop(_idx); }
             return (*this);
         }
         case zpt::JSString: {


### PR DESCRIPTION
Added authorization infra-structure:

- `authorized()` method added to events to validate before execution.
- throwing proper exception and unauthorized reply.