### PR TITLE
Transport info in `process`

### DIFF
--- a/engines/transport/include/zapata/transport/engine.h
+++ b/engines/transport/include/zapata/transport/engine.h
@@ -204,6 +204,8 @@ class process {
     auto operator=(zpt::events::process const& _rhs) -> process& = delete;
     auto operator=(zpt::events::process&& _rhs) -> process& = delete;
 
+    /** @brief Returns the type of transport used to receive the message. */
+    virtual auto transport_type() -> std::string const& final;
     /** @brief Returns the received message. */
     virtual auto received() const -> zpt::message const final;
     /** @brief Returns the message to send as response. */

--- a/engines/transport/src/engine.cpp
+++ b/engines/transport/src/engine.cpp
@@ -208,6 +208,10 @@ zpt::events::process::~process() {
 #endif
 }
 
+auto zpt::events::process::transport_type() -> std::string const& {
+    return this->__strean->transport();
+}
+
 auto zpt::events::process::received() const -> zpt::message const { return this->__received; }
 
 auto zpt::events::process::to_send() -> zpt::message { return this->__to_send; }


### PR DESCRIPTION
Added to `events::process` the information about the transport used to receive the message.