### PR TITLE
Adding foreign entity reference in code generation

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -37,3 +37,33 @@ AllowShortFunctionsOnASingleLine: true
 AllowShortIfStatementsOnASingleLine: true
 AllowShortLambdasOnASingleLine: true
 AllowShortLoopsOnASingleLine: true
+
+---
+
+Language: JavaScript
+ColumnLimit: 100
+IndentWidth: 4
+TabWidth: 4
+BreakBeforeBraces: Custom
+BraceWrapping:
+    AfterClass: false
+    AfterControlStatement: false
+    AfterEnum: false
+    AfterFunction: false
+    AfterNamespace: false
+    AfterStruct: false
+    AfterUnion: false
+    AfterExternBlock: false
+    BeforeCatch: true
+    BeforeElse: true
+    SplitEmptyFunction: false
+    SplitEmptyRecord: false
+    SplitEmptyNamespace: false
+
+---
+
+Language: Json
+ColumnLimit: 100
+IndentWidth: 4
+TabWidth: 4
+

--- a/generators/rest/src/rest.cpp
+++ b/generators/rest/src/rest.cpp
@@ -1170,8 +1170,15 @@ auto zpt::gen::rest::unit::generate_sql_schemata_mysql(zpt::json _def)
                  << (_object("required")->contains(_name) ? " not null" : "") << "," << std::endl;
             if (_field("sql:index")->ok()) {
                 auto _index_type = _field("sql:index")->string();
-                _oss << (_index_type == "unique" ? "unique " : "") << "key " << _name << "_"
-                     << _field("sql:index")->string() << "_idx(" << _name << ")," << std::endl;
+                if (_index_type == "foreign") {
+                    _oss << "foreign key " << _name << "_" << _index_type << "_idx(" << _name
+                         << ") references " << _field("sql:references")->string() << ","
+                         << std::endl;
+                }
+                else {
+                    _oss << (_index_type == "unique" ? "unique " : "") << "key " << _name << "_"
+                         << _index_type << "_idx(" << _name << ")," << std::endl;
+                }
             }
         }
     }


### PR DESCRIPTION
- `sql:index "foreign"` added to list of supported indexes.
- `sql:references: "table(column)"` added to schema definition.