### PR TITLE
Properly escaping JSON columns in MySQL connector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,3 +132,17 @@ if(NOT TARGET uninstall)
   add_custom_target(uninstall
     COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
 endif()
+
+# Print flags
+include(CMakePrintHelpers)
+cmake_print_variables(CMAKE_VERSION)
+cmake_print_variables(CMAKE_GENERATOR)
+cmake_print_variables(CMAKE_C_COMPILER)
+cmake_print_variables(CMAKE_CXX_COMPILER)
+cmake_print_variables(CMAKE_CXX_COMPILER_VERSION)
+cmake_print_variables(CMAKE_BUILD_TYPE)
+cmake_print_variables(CMAKE_CXX_FLAGS)
+cmake_print_variables(CMAKE_C_FLAGS)
+cmake_print_variables(CMAKE_CXX_LINK_FLAGS)
+cmake_print_variables(WITH_ASAN)
+cmake_print_variables(WITH_UBSAN)

--- a/cmake/zapata_external_project.cmake
+++ b/cmake/zapata_external_project.cmake
@@ -7,6 +7,8 @@ ExternalProject_Add(zapata
   CMAKE_ARGS
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
     -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+    -DWITH_ASAN=${WITH_ASAN}
+    -DWITH_UBSAN=${WITH_UBSAN}
 )
 
 include_directories(

--- a/common/base/include/zapata/text/manip.h
+++ b/common/base/include/zapata/text/manip.h
@@ -68,6 +68,16 @@ void trim(std::string& _in_out);
 auto replace(std::string& str, std::string const& find, std::string const& replace) -> void;
 
 /**
+ * @brief Replaces all occurrences of a list of substrings (in-place).
+ * @param str String to modify.
+ * @param find List of substrings to search for.
+ * @param replace List of replacements string.
+ */
+auto replace_multiple(std::string& _str,
+                      std::vector<std::string> const& _find,
+                      std::vector<std::string> const& _replace) -> void;
+
+/**
  * @brief Normalizes a file path (in-place).
  * @param _in_out Path to normalize.
  * @param _with_trailing Whether to include trailing slash.
@@ -113,6 +123,17 @@ std::string r_trim(std::string const& _in_out);
  * @return Modified copy.
  */
 std::string r_replace(std::string const& str, std::string const& find, std::string const& replace);
+
+/**
+ * @brief Returns a copy with all occurrences of a list of substrings replaced.
+ * @param str Input string.
+ * @param find List of substrings to search for.
+ * @param replace List of replacement strings.
+ * @return Modified copy.
+ */
+auto r_replace_multiple(std::string const& _str,
+                        std::vector<std::string> const& _find,
+                        std::vector<std::string> const& _replace) -> std::string;
 
 /**
  * @brief Returns a normalized copy of a file path.

--- a/common/base/src/manip.cpp
+++ b/common/base/src/manip.cpp
@@ -63,6 +63,30 @@ auto zpt::replace(std::string& str, std::string const& find, std::string const& 
     }
 }
 
+auto zpt::replace_multiple(std::string& _str,
+                           std::vector<std::string> const& _find,
+                           std::vector<std::string> const& _replace) -> void {
+    if (_str.length() == 0) { return; }
+
+    size_t _start{ 0 };
+    while (true) {
+        size_t _which{ 0 };
+        size_t _next{ std::string::npos };
+        for (size_t _idx = 0; _idx != _find.size(); ++_idx) {
+            auto _found = _str.find(_find[_idx], _start);
+            if (_found < _next) {
+                _next = _found;
+                _which = _idx;
+            }
+        }
+        if (_next != std::string::npos) {
+            _str.replace(_next, _find[_which].size(), _replace[_which]);
+            _start = _next + _replace[_which].length();
+        }
+        else { break; }
+    }
+}
+
 auto zpt::normalize_path(std::string& _in_out, bool _with_trailing) -> void {
     if (_with_trailing) {
         if (_in_out[_in_out.length() - 1] != '/') { _in_out.insert(_in_out.length(), "/"); }
@@ -113,14 +137,15 @@ auto zpt::r_trim(std::string const& _in_out) -> std::string {
 auto zpt::r_replace(std::string const& str, std::string const& find, std::string const& replace)
   -> std::string {
     std::string _return{ str.data() };
-    if (_return.length() == 0) { return _return; }
+    zpt::replace(_return, find, replace);
+    return _return;
+}
 
-    size_t start{ 0 };
-
-    while ((start = _return.find(find, start)) != std::string::npos) {
-        _return.replace(start, find.size(), replace);
-        start += replace.length();
-    }
+auto zpt::r_replace_multiple(std::string const& _str,
+                             std::vector<std::string> const& _find,
+                             std::vector<std::string> const& _replace) -> std::string {
+    std::string _return{ _str.data() };
+    zpt::replace_multiple(_return, _find, _replace);
     return _return;
 }
 

--- a/storage/mysqlx/src/test.cpp
+++ b/storage/mysqlx/src/test.cpp
@@ -1,7 +1,7 @@
 #include <zapata/mysqlx.h>
 
 auto main(int, char**) -> int {
-    zpt::json _config{ { "storage", { "mysqlx", { "user", "root", "host", "127.0.0.1" } } } };
+    zpt::json _config{ { "storage", { "mysqlx", { "user", "zpt", "host", "127.0.0.1" } } } };
     auto _connection = zpt::make_connection<zpt::storage::mysqlx::connection>(_config);
     auto _session = _connection->session();
     _session->sql("create schema if not exists test");
@@ -13,7 +13,7 @@ auto main(int, char**) -> int {
       ->remove({})
       ->execute();
     auto _ids = _collection //
-                  ->add({ "name", "John Smith", "address", "Upside Down" })
+                  ->add({ "name", "John Smith", "address", "Upside Down 'just for fun' with {}" })
                   ->execute()
                   ->generated_id();
 
@@ -26,12 +26,12 @@ auto main(int, char**) -> int {
 
     _collection //
       ->modify(std::format("_id = \"{}\"", _ids(0)->string()))
-      ->set("name", "Zé Povinho")
+      ->set("name", "Zé Povinho 'or with {}'")
       ->execute();
 
     _collection //
       ->modify(std::format("_id = \"{}\"", _ids(0)->string()))
-      ->patch({ "name", "Pixie", "address", "Neverland" })
+      ->patch({ "name", "Pixie", "address", "Neverland or a placeholder like '{}'" })
       ->execute();
 
     std::cout << zpt::pretty(_collection->find({})->execute()->fetch()) << std::endl;

--- a/storage/mysqlx/src/translate.cpp
+++ b/storage/mysqlx/src/translate.cpp
@@ -401,7 +401,11 @@ auto zpt::storage::mysqlx::quote(zpt::json _to_quote) -> std::string {
                   _to_quote->type() == zpt::JSRegex || _to_quote->type() == zpt::JSArray ||
                   _to_quote->type() == zpt::JSObject;
     std::ostringstream _oss;
-    _oss << (_needs ? "'" : "") << (_to_quote->ok() ? static_cast<std::string>(_to_quote) : "NULL")
+    _oss << (_needs ? "'" : "")
+         << (_to_quote->ok() ? zpt::r_replace_multiple(static_cast<std::string>(_to_quote),
+                                                       { "'", "{", "}" },
+                                                       { "\\'", "{{", "}}" })
+                             : "NULL")
          << (_needs ? "'" : "") << std::flush;
     return _oss.str();
 }


### PR DESCRIPTION
- Introduced `zpt::replace_multiple`, which allows to replace several sub-strings with a given string in a more efficient way that several `zpt::replace` executions.
- Escape `'`, `{`, `}` in SQL strings for MySQL connector.