### PR TITLE
Custom allocator

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ int main(int argc, char* argv[]) {
     _engine->on("GET", "/hello/{name}",
         [](zpt::performative _performative,
            zpt::json _envelope,
-           zpt::rest::engine& _engine) -> zpt::json {
+           zpt::rest::engine::ptr _engine) -> zpt::json {
             auto _name = _envelope["params"]["name"];
             return { "message", std::string("Hello, ") + _name->string() };
         });

--- a/common/base/include/zapata/allocator/allocator.h
+++ b/common/base/include/zapata/allocator/allocator.h
@@ -32,6 +32,8 @@
 
 #include <atomic>
 #include <cassert>
+#include <format>
+#include <functional>
 #include <map>
 #include <memory>
 #include <stddef.h>
@@ -90,6 +92,13 @@ class pool {
      */
     auto allocated_size() const -> size_t;
 
+    auto to_string() const -> std::string;
+
+    friend auto operator<<(std::ostream& _out, zpt::mem::pool& _in) -> std::ostream& {
+        _out << _in.to_string();
+        return _out;
+    }
+
   private:
     zpt::padded_atomic<size_t> __max_size{ 0 };       ///< Maximum allowed allocation.
     zpt::padded_atomic<size_t> __allocated_size{ 0 }; ///< Current allocation.
@@ -130,6 +139,9 @@ class allocator {
     using void_pointer = void*;
     using const_void_pointer = void const*;
     using size_type = size_t;
+    using unique_pointer = std::unique_ptr<T, std::function<void(void*)>>;
+    using array_pointer = std::unique_ptr<T[], std::function<void(void*)>>;
+    using shared_pointer = std::shared_ptr<T>;
 
     zpt::mem::pool& __pool; ///< Reference to the backing memory pool.
 
@@ -204,6 +216,12 @@ class allocator {
     auto destroy(pointer p) -> void;
 };
 
+template<typename T, typename... Args>
+auto allocate_shared(Args... _args) -> zpt::allocator<T>::shared_pointer;
+template<typename T, typename... Args>
+auto allocate_unique(Args... _args) -> zpt::allocator<T>::unique_pointer;
+template<typename T>
+auto allocate_array(size_t _size) -> zpt::allocator<T>::array_ponter;
 } // namespace zpt
 
 template<class T>
@@ -261,4 +279,41 @@ template<typename T>
 auto zpt::allocator<T>::destroy(pointer p) -> void {
     expect(p != nullptr, "can't destroy an object instance from unallocated memory");
     p->~T();
+}
+
+template<typename T, typename... Args>
+auto zpt::allocate_shared(Args... _args) -> zpt::allocator<T>::shared_pointer {
+    return std::allocate_shared<T>(zpt::allocator<T>{ zpt::MEM_POOL() },
+                                   std::forward<Args>(_args)...);
+}
+
+template<typename T, typename... Args>
+auto zpt::allocate_unique(Args... _args) -> zpt::allocator<T>::unique_pointer {
+    auto _deleter = [](void* _p) {
+        zpt::allocator<T> _allocator{ zpt::MEM_POOL() };
+        auto _allocated = static_cast<T*>(_p);
+        _allocator.deallocate(_allocated, 1);
+    };
+
+    zpt::allocator<T> _allocator{ zpt::MEM_POOL() };
+    auto _allocated = _allocator.allocate(1);
+    _allocator.construct(_allocated, _args...);
+
+    return { _allocated, _deleter };
+}
+
+template<typename T>
+auto zpt::allocate_array(size_t _n_elements) -> zpt::allocator<T>::array_pointer {
+    auto _deleter = [](void* _p, size_t _n) {
+        zpt::allocator<T> _allocator{ zpt::MEM_POOL() };
+        auto _allocated = static_cast<T*>(_p);
+        for (size_t _idx = 0; _idx != _n; ++_idx) { _allocator.destroy(&_allocated[_idx]); }
+        _allocator.deallocate(_allocated, _n);
+    };
+
+    zpt::allocator<T> _allocator{ zpt::MEM_POOL() };
+    auto _allocated = _allocator.allocate(_n_elements);
+    for (size_t _idx = 0; _idx != _n_elements; ++_idx) { _allocator.construct(&_allocated[_idx]); }
+
+    return { _allocated, std::bind(_deleter, std::placeholders::_1, _n_elements) };
 }

--- a/common/base/include/zapata/allocator/allocator.h
+++ b/common/base/include/zapata/allocator/allocator.h
@@ -296,12 +296,13 @@ auto zpt::allocate_unique(Args... _args) -> zpt::allocator<T>::unique_pointer {
     auto _deleter = [](void* _p) {
         zpt::allocator<T> _allocator{ zpt::MEM_POOL() };
         auto _allocated = static_cast<T*>(_p);
+        _allocator.destroy(_allocated);
         _allocator.deallocate(_allocated, 1);
     };
 
     zpt::allocator<T> _allocator{ zpt::MEM_POOL() };
     auto _allocated = _allocator.allocate(1);
-    _allocator.construct(_allocated, _args...);
+    _allocator.construct(_allocated, std::forward<Args>(_args)...);
 
     return { _allocated, _deleter };
 }

--- a/common/base/include/zapata/allocator/allocator.h
+++ b/common/base/include/zapata/allocator/allocator.h
@@ -58,10 +58,9 @@ class pool {
     using pointer_type = void*; ///< Generic pointer type.
 
     /**
-     * @brief Creates a pool with the specified maximum memory.
-     * @param _max_memory Maximum bytes this pool can allocate.
+     * @brief Creates a pool with unbounded memory limit.
      */
-    pool(size_t _max_memory);
+    pool();
 
     virtual ~pool();
 
@@ -80,6 +79,12 @@ class pool {
      */
     auto deallocate(pointer_type _ptr, size_t _n) -> void;
 
+    /**
+     * @brief Sets the new limit for total memory allocation.
+     * @param _max_memory The new limit.
+     * @return This instance's reference, for chaining purposes.
+     */
+    auto max_size(size_t _max_memory) -> pool&;
     /**
      * @brief Returns the maximum pool size.
      * @return Maximum bytes this pool can allocate.
@@ -108,10 +113,9 @@ class pool {
 
 /**
  * @brief Returns the global memory pool singleton.
- * @param _max_mem If non-zero on first call, sets the pool's maximum size.
  * @return Reference to the global memory pool.
  */
-auto MEM_POOL(std::uint64_t _max_mem = 0) -> zpt::mem::pool&;
+auto MEM_POOL() -> zpt::mem::pool&;
 
 /**
  * @brief STL-compatible allocator backed by a memory pool.

--- a/common/base/src/allocator.cpp
+++ b/common/base/src/allocator.cpp
@@ -1,12 +1,12 @@
 #include <zapata/allocator.h>
 
-auto zpt::MEM_POOL(std::uint64_t _max_mem) -> zpt::mem::pool& {
-    static zpt::mem::pool _global{ _max_mem };
+auto zpt::MEM_POOL() -> zpt::mem::pool& {
+    static zpt::mem::pool _global;
     return _global;
 }
 
-zpt::mem::pool::pool(size_t _max_memory)
-  : __max_size{ _max_memory }
+zpt::mem::pool::pool()
+  : __max_size{ 0 }
   , __allocated_size{ 0 } {}
 
 zpt::mem::pool::~pool() {}
@@ -29,6 +29,13 @@ auto zpt::mem::pool::allocate(size_t _n) -> pointer_type {
 auto zpt::mem::pool::deallocate(pointer_type _ptr, size_t _n) -> void {
     this->__allocated_size->fetch_add(-_n);
     ::free(_ptr);
+}
+
+auto zpt::mem::pool::max_size(size_t _max_memory) -> pool& {
+    if (_max_memory > this->max_size() && _max_memory > this->allocated_size()) {
+        this->__max_size->store(_max_memory);
+    }
+    return (*this);
 }
 
 auto zpt::mem::pool::max_size() const -> size_t { return this->__max_size->load(); }

--- a/common/base/src/allocator.cpp
+++ b/common/base/src/allocator.cpp
@@ -15,21 +15,27 @@ auto zpt::mem::pool::allocate(size_t _n) -> pointer_type {
     while (true) {
         auto _current_size = this->__allocated_size->load(std::memory_order_acquire);
         auto _new_size = _current_size + _n;
-        expect(this->__max_size->load() == 0 || _new_size <= this->__max_size->load(),
-               "reached max memory limit of " << this->__max_size << " bytes");
+        if (this->__max_size->load() != 0 && _new_size >= this->__max_size->load()) {
+            throw std::bad_alloc{};
+        }
         if (this->__allocated_size->compare_exchange_strong(
               _current_size, _new_size, std::memory_order_release)) {
             break;
         }
     }
-    return malloc(_n);
+    return ::malloc(_n);
 }
 
 auto zpt::mem::pool::deallocate(pointer_type _ptr, size_t _n) -> void {
     this->__allocated_size->fetch_add(-_n);
-    free(_ptr);
+    ::free(_ptr);
 }
 
 auto zpt::mem::pool::max_size() const -> size_t { return this->__max_size->load(); }
 
 auto zpt::mem::pool::allocated_size() const -> size_t { return this->__allocated_size->load(); }
+
+auto zpt::mem::pool::to_string() const -> std::string {
+    return std::format(
+      "{{ \"max\": {}, \"allocated\": {} }}", this->max_size(), this->allocated_size());
+}

--- a/common/base/src/test.cpp
+++ b/common/base/src/test.cpp
@@ -30,7 +30,7 @@ class A {
 
 auto main(int, char*[]) -> int {
     {
-        zpt::mem::pool _pool{ 64 };
+        zpt::mem::pool _pool{ 0 };
         for (size_t _idx = 0; _idx != 100; ++_idx) {
             std::shared_ptr<A> _ptr = std::allocate_shared<A>(zpt::allocator<A>{ _pool });
             std::cout << "Allocate object holding '" << _ptr->__member << "'" << std::endl;

--- a/common/base/src/test.cpp
+++ b/common/base/src/test.cpp
@@ -30,7 +30,7 @@ class A {
 
 auto main(int, char*[]) -> int {
     {
-        zpt::mem::pool _pool{ 0 };
+        zpt::mem::pool _pool;
         for (size_t _idx = 0; _idx != 100; ++_idx) {
             std::shared_ptr<A> _ptr = std::allocate_shared<A>(zpt::allocator<A>{ _pool });
             std::cout << "Allocate object holding '" << _ptr->__member << "'" << std::endl;
@@ -38,7 +38,8 @@ auto main(int, char*[]) -> int {
     }
     {
         try {
-            zpt::mem::pool _pool{ sizeof(A) };
+            zpt::mem::pool _pool;
+            _pool.max_size(sizeof(A));
             for (size_t _idx = 0; _idx != 100; ++_idx) {
                 std::shared_ptr<A> _ptr = std::allocate_shared<A>(zpt::allocator<A>{ _pool });
             }
@@ -51,7 +52,8 @@ auto main(int, char*[]) -> int {
         }
     }
     {
-        zpt::mem::pool _pool{ 1024 * 1024 * 1024 };
+        zpt::mem::pool _pool;
+        _pool.max_size(1024 * 1024 * 1024);
         {
             std::vector<A, zpt::allocator<A>> _v{ zpt::allocator<A>{ _pool } };
             for (size_t _idx = 0; _idx != 100; ++_idx) {

--- a/common/events/include/zapata/events/dispatcher.h
+++ b/common/events/include/zapata/events/dispatcher.h
@@ -78,7 +78,7 @@ enum state {
  * any thread and will be processed by available consumers.
  *
  * @par Lifecycle
- * 1. Create dispatcher with `zpt::DISPATCHER(n_consumers, n_producers)`
+ * 1. Create dispatcher with `zpt::DISPATCHER(n_consumers, max_queue_size)`
  * 2. Register event handlers or initialization data
  * 3. Call `start_consumers()` to begin processing
  * 4. Trigger events with `trigger<T>(args...)`
@@ -104,7 +104,7 @@ class dispatcher : public std::enable_shared_from_this<dispatcher> {
      * @param _max_queue_size Maximum number of elements allowed in the queue (resource management
      *                        cap).
      */
-    dispatcher(std::string const& _name, long _max_consumers, size_t _max_queue_size);
+    dispatcher(std::string const& _name, long _max_consumers, size_t _max_queue_size = 10000);
     /** @brief Destructor. Stops consumers if running. */
     virtual ~dispatcher();
 
@@ -270,10 +270,11 @@ auto make_event(Args&&... _args) -> zpt::event;
 /**
  * @brief Factory function to create a dispatcher.
  * @param _consumers Number of consumer threads.
- * @param _producers Maximum producer threads for queue sizing.
+ * @param _max_queue_size Maximum size for event queue.
  * @return Shared pointer to the dispatcher.
  */
-auto DISPATCHER(long int _consumers = 0, long int _producers = 0) -> zpt::events::dispatcher::ptr;
+auto DISPATCHER(long int _consumers = 0, size_t _max_queue_size = 0)
+  -> zpt::events::dispatcher::ptr;
 
 /**
  * @brief Casts an event to access its underlying Operation.

--- a/common/events/include/zapata/events/dispatcher.h
+++ b/common/events/include/zapata/events/dispatcher.h
@@ -43,7 +43,7 @@ namespace zpt {
 /** @brief Forward declaration of abstract event interface. */
 class abstract_event;
 /** @brief Shared pointer type for events. */
-using event = std::unique_ptr<zpt::abstract_event>;
+using event = zpt::allocator<zpt::abstract_event>::unique_pointer;
 
 /**
  * @brief Base class for event initialization data.
@@ -202,7 +202,7 @@ class abstract_event {
     /** @brief Executes the event operation. */
     virtual auto operator()(zpt::events::dispatcher::ptr _dispatcher) -> zpt::events::state = 0;
 };
-using event = std::unique_ptr<zpt::abstract_event>;
+using event = zpt::allocator<zpt::abstract_event>::unique_pointer;
 
 /**
  * @brief Type-erasing wrapper for Operation types.
@@ -340,12 +340,12 @@ auto zpt::event_t<T>::operator()(zpt::events::dispatcher::ptr _dispatcher) -> zp
 
 template<zpt::events::Operation T>
 auto zpt::make_event(T _operator) -> zpt::event {
-    return std::make_unique<zpt::event_t<T>>(_operator);
+    return zpt::allocate_unique<zpt::event_t<T>>(_operator);
 }
 
 template<zpt::events::Operation T, typename... Args>
 auto zpt::make_event(Args&&... _args) -> zpt::event {
-    return std::make_unique<zpt::event_t<T>>(std::forward<Args>(_args)...);
+    return zpt::allocate_unique<zpt::event_t<T>>(std::forward<Args>(_args)...);
 }
 
 template<typename T, typename... Args>

--- a/common/events/include/zapata/events/dispatcher.h
+++ b/common/events/include/zapata/events/dispatcher.h
@@ -36,6 +36,7 @@
 #include <memory>
 #include <zapata/allocator.h>
 #include <zapata/base.h>
+#include <zapata/json.h>
 #include <zapata/lockfree.h>
 
 namespace zpt {
@@ -130,6 +131,8 @@ class dispatcher : public std::enable_shared_from_this<dispatcher> {
     auto trap() -> dispatcher&;
     /** @brief Checks if shutdown has been initiated. */
     auto is_in_shutdown() -> bool;
+    /** @brief Retrieves the dispatcher's internal state. */
+    auto get_state() const -> zpt::json;
 
   public:
     zpt::lf::queue<zpt::abstract_event> __queue;

--- a/common/events/src/dispatcher.cpp
+++ b/common/events/src/dispatcher.cpp
@@ -105,6 +105,12 @@ auto zpt::events::dispatcher::trap() -> dispatcher& {
 
 auto zpt::events::dispatcher::is_in_shutdown() -> bool { return this->__shutdown->load(); }
 
+auto zpt::events::dispatcher::get_state() const -> zpt::json {
+    return { "name",    this->__name,
+             "workers", static_cast<size_t>(this->__max_consumers),
+             "queue",   { "capacity", this->__queue.capacity(), "size", this->__queue.size() } };
+}
+
 auto zpt::events::dispatcher::loop(long _consumer_nr) -> void {
     zpt::this_thread::timer<float> _timer{ 0.005f };
     auto _name = std::format("{}@{}", this->__name, _consumer_nr);

--- a/common/events/src/dispatcher.cpp
+++ b/common/events/src/dispatcher.cpp
@@ -128,8 +128,8 @@ auto zpt::events::dispatcher::loop(long _consumer_nr) -> void {
     zlog(_name << " stopping", zpt::trace);
 }
 
-auto zpt::DISPATCHER(long int _consumers, long int _producers) -> zpt::events::dispatcher::ptr {
+auto zpt::DISPATCHER(long int _consumers, size_t _max_queue_size) -> zpt::events::dispatcher::ptr {
     static zpt::events::dispatcher::ptr _global =
-      zpt::allocate_shared<zpt::events::dispatcher>("globald", _consumers, _producers);
+      zpt::allocate_shared<zpt::events::dispatcher>("globald", _consumers, _max_queue_size);
     return _global;
 }

--- a/common/events/src/dispatcher.cpp
+++ b/common/events/src/dispatcher.cpp
@@ -130,6 +130,6 @@ auto zpt::events::dispatcher::loop(long _consumer_nr) -> void {
 
 auto zpt::DISPATCHER(long int _consumers, long int _producers) -> zpt::events::dispatcher::ptr {
     static zpt::events::dispatcher::ptr _global =
-      std::make_shared<zpt::events::dispatcher>("globald", _consumers, _producers);
+      zpt::allocate_shared<zpt::events::dispatcher>("globald", _consumers, _producers);
     return _global;
 }

--- a/common/events/src/system_events.cpp
+++ b/common/events/src/system_events.cpp
@@ -126,6 +126,6 @@ auto zpt::system_events::resolver_t::clear() -> resolver_t& {
 
 auto zpt::SYSTEM_EVENTS_RESOLVER() -> zpt::system_events::resolver {
     static zpt::system_events::resolver _global =
-      std::make_shared<zpt::system_events::resolver_t>();
+      zpt::allocate_shared<zpt::system_events::resolver_t>();
     return _global;
 }

--- a/common/events/src/test.cpp
+++ b/common/events/src/test.cpp
@@ -73,21 +73,21 @@ class my_other_operator {
 };
 
 auto main(int, char**) -> int {
-    zpt::events::dispatcher _dispatcher{ "test", 10, 1 };
+    auto _dispatcher = std::make_shared<zpt::events::dispatcher>("test", 10, 100);
 
     _dispatcher //
-      .start_consumers()
+      ->start_consumers()
       .trigger<my_operator>("some string", 1)
       .trigger<my_other_operator>(1);
 
     std::this_thread::sleep_for(std::chrono::duration<int>{ 10 });
     _dispatcher //
-      .stop_consumers();
+      ->stop_consumers();
 
     zlog("Stopping for 2s and restarting threads", zpt::info);
     std::this_thread::sleep_for(std::chrono::duration<int>{ 2 });
     _dispatcher //
-      .start_consumers();
+      ->start_consumers();
 
     std::this_thread::sleep_for(std::chrono::duration<int>{ 10 });
 }

--- a/common/lockfree/include/zapata/lockfree/queue.h
+++ b/common/lockfree/include/zapata/lockfree/queue.h
@@ -38,6 +38,7 @@
 
 #pragma once
 
+#include <zapata/allocator.h>
 #include <zapata/atomics/padded_atomic.h>
 #include <zapata/base/sentry.h>
 #include <zapata/exceptions/exceptions.h>
@@ -90,7 +91,7 @@ template<typename T>
 class queue {
   public:
     using size_type = size_t;
-    using ptr = std::unique_ptr<T>;
+    using ptr = zpt::allocator<T>::unique_pointer;
 
     /**
      * @brief Constructs a bounded queue with the given fixed capacity.
@@ -154,7 +155,7 @@ class queue {
     }
 
   private:
-    std::unique_ptr<ptr[]> __elements{ nullptr };
+    zpt::allocator<ptr>::array_pointer __elements{ nullptr };
     zpt::padded_atomic<__uint128_t> __boundaries{ 0 };
     zpt::padded_atomic<std::uint64_t> __size{ 0 };
     size_t __capacity{ 0 };
@@ -167,13 +168,13 @@ class queue {
 
 template<typename T>
 zpt::lf::queue<T>::queue(size_t _max_queue_size)
-  : __elements{ std::make_unique<ptr[]>(_max_queue_size) }
+  : __elements{ zpt::allocate_array<ptr>(_max_queue_size) }
   , __boundaries{ 0 }
   , __capacity{ _max_queue_size } {}
 
 template<typename T>
 auto zpt::lf::queue<T>::push(T _value) -> zpt::lf::queue<T>& {
-    return this->push(std::make_unique<T>(_value));
+    return this->push(zpt::allocate_unique<T>(_value));
 }
 
 template<typename T>

--- a/common/lockfree/include/zapata/lockfree/queue.h
+++ b/common/lockfree/include/zapata/lockfree/queue.h
@@ -129,6 +129,8 @@ class queue {
      */
     auto pop() -> ptr;
 
+    /** @brief Returns the queue maximum number of elements. */
+    auto capacity() const -> size_t;
     /** @brief Returns approximate element count. */
     auto size() const -> size_t;
 
@@ -219,6 +221,11 @@ auto zpt::lf::queue<T>::pop() -> ptr {
         std::this_thread::yield();
     }
     throw NoMoreElementsException("no element to pop");
+}
+
+template<typename T>
+auto zpt::lf::queue<T>::capacity() const -> size_t {
+    return this->__capacity;
 }
 
 template<typename T>

--- a/common/ontology/include/zapata/ontology/message.h
+++ b/common/ontology/include/zapata/ontology/message.h
@@ -259,12 +259,12 @@ auto operator>>(std::istream& _in, zpt::message _out) -> std::istream&;
 
 template<typename T, typename... Args>
 auto zpt::make_message(Args... _args) -> zpt::message {
-    return std::make_shared<T>(std::forward<Args>(_args)...);
+    return zpt::allocate_shared<T>(std::forward<Args>(_args)...);
 }
 
 template<typename T, typename... Args>
 auto zpt::allocate_message(Args... _args) -> zpt::message {
-    return std::make_shared<T>(std::forward<Args>(_args)...);
+    return zpt::allocate_shared<T>(std::forward<Args>(_args)...);
     // return std::allocate_shared<T>(zpt::allocator<T>{ zpt::MEM_POOL() },
     //                                std::forward<Args>(_args)...);
 }

--- a/docs/api-reference/bridges-generators.md
+++ b/docs/api-reference/bridges-generators.md
@@ -527,13 +527,13 @@ concept BasicASTElement = requires(T _t) {
 #include <zapata/ast.h>
 
 // Create a module with a header file
-auto file = std::make_shared<zpt::ast::basic_file>("my_class.h");
+auto file = zpt::allocate_shared<zpt::ast::basic_file>("my_class.h");
 
 // Create a class
-auto cls = std::make_shared<zpt::ast::cpp_class>("MyClass", "BaseClass");
+auto cls = zpt::allocate_shared<zpt::ast::cpp_class>("MyClass", "BaseClass");
 
 // Add a public method
-auto method = std::make_shared<zpt::ast::cpp_function>(
+auto method = zpt::allocate_shared<zpt::ast::cpp_function>(
     "process",
     "void",
     zpt::ast::VIRTUAL | zpt::ast::OVERRIDE
@@ -543,7 +543,7 @@ auto method = std::make_shared<zpt::ast::cpp_function>(
 method->add<zpt::ast::cpp_variable>("input", "std::string const&", zpt::ast::PARAMETER);
 
 // Add method body
-auto body = std::make_shared<zpt::ast::cpp_code_block>();
+auto body = zpt::allocate_shared<zpt::ast::cpp_code_block>();
 body->add<zpt::ast::cpp_instruction>("std::cout << input << std::endl");
 method->add(body);
 

--- a/docs/api-reference/events.md
+++ b/docs/api-reference/events.md
@@ -235,7 +235,7 @@ Constructs the underlying Operation with forwarded arguments.
 ### `zpt::DISPATCHER`
 
 ```cpp
-auto DISPATCHER(long int _consumers = 0, long int _producers = 0)
+auto DISPATCHER(long int _consumers = 0, long int _max_queue_size = 10000)
     -> zpt::events::dispatcher::ptr;
 ```
 

--- a/docs/api-reference/io.md
+++ b/docs/api-reference/io.md
@@ -565,7 +565,7 @@ std::string msg;
 #include <zapata/streams.h>
 
 auto poll = zpt::STREAM_POLLING();
-auto signal = std::make_shared<zpt::event_stream>();
+auto signal = zpt::allocate_shared<zpt::event_stream>();
 
 poll->register_delegate([](zpt::polling::ptr p, zpt::stream s) {
     std::any data;

--- a/docs/api-reference/lockfree.md
+++ b/docs/api-reference/lockfree.md
@@ -191,7 +191,7 @@ void consumer() {
 zpt::lf::queue<std::vector<char>> buffer_queue(256);
 
 // Producer: build and enqueue without an extra copy
-auto buf = std::make_unique<std::vector<char>>(4096);
+auto buf = zpt::allocate_unique<std::vector<char>>(4096);
 fill_buffer(*buf);
 buffer_queue.push(std::move(buf));
 

--- a/docs/api-reference/rest.md
+++ b/docs/api-reference/rest.md
@@ -270,13 +270,13 @@ int main() {
         });
 
     // Start the transport engine
-    auto& engine = zpt::TRANSPORT_ENGINE(config);
-    engine.add_resolver(resolver);
+    auto engine = zpt::TRANSPORT_ENGINE(config);
+    engine->add_resolver(resolver);
 
     boot.load();
 
     // Run until shutdown
-    engine.dispatcher()->trap();
+    engine->dispatcher()->trap();
 }
 ```
 

--- a/docs/api-reference/transport.md
+++ b/docs/api-reference/transport.md
@@ -1,19 +1,19 @@
-# Transport API Reference
+#Transport API Reference
 
 This document provides the API reference for Zapata's transport layer.
 
 ## Headers
 
 ```cpp
-#include <zapata/transport.h>              // Core transport abstractions
-#include <zapata/transport/engine.h>       // Transport engine
-#include <zapata/net/transport/http.h>     // HTTP transport
-#include <zapata/net/transport/tcp.h>      // TCP transport
+#include <zapata/net/transport/http.h>      // HTTP transport
+#include <zapata/net/transport/local.h>     // Unix socket / file transports
+#include <zapata/net/transport/pipe.h>      // Named pipe transport
+#include <zapata/net/transport/self.h>      // In-process transport
+#include <zapata/net/transport/tcp.h>       // TCP transport
+#include <zapata/net/transport/upnp.h>      // UPnP/SSDP transport
 #include <zapata/net/transport/websocket.h> // WebSocket transport
-#include <zapata/net/transport/local.h>    // Unix socket / file transports
-#include <zapata/net/transport/pipe.h>     // Named pipe transport
-#include <zapata/net/transport/self.h>     // In-process transport
-#include <zapata/net/transport/upnp.h>     // UPnP/SSDP transport
+#include <zapata/transport.h>               // Core transport abstractions
+#include <zapata/transport/engine.h>        // Transport engine
 ```
 
 ---
@@ -45,12 +45,12 @@ Abstract base class for protocol transports.
 virtual auto has_capability(std::uint64_t _capability) const -> bool = 0;
 ```
 
-Checks if the transport has a specific capability.
+  Checks if the transport has a specific capability.
 
----
+  -- -
 
-```cpp
-virtual auto make_request() const -> zpt::message = 0;
+```cpp virtual auto
+  make_request() const -> zpt::message = 0;
 ```
 
 Creates a new request message for this transport.
@@ -62,21 +62,23 @@ virtual auto make_reply(bool _with_allocator = true) const -> zpt::message = 0;
 virtual auto make_reply(zpt::message _request) const -> zpt::message = 0;
 ```
 
-Creates a reply message, optionally based on a request.
+  Creates a reply message,
+  optionally based on a request.
 
----
+  -- -
 
-```cpp
-virtual auto process_incoming_request(zpt::stream _stream) const -> zpt::message = 0;
+```cpp virtual auto
+  process_incoming_request(zpt::stream _stream) const -> zpt::message = 0;
 virtual auto process_incoming_reply(zpt::stream _stream) const -> zpt::message = 0;
 ```
 
-Parses incoming requests/replies from a stream.
+  Parses incoming requests /
+  replies from a stream.
 
----
+  -- -
 
-```cpp
-auto receive(zpt::stream _stream) const -> zpt::message;
+```cpp auto
+  receive(zpt::stream _stream) const -> zpt::message;
 auto send(zpt::stream _stream, zpt::message _to_send) const -> void;
 ```
 
@@ -90,40 +92,41 @@ High-level methods for receiving/sending messages (final).
 using transport = std::shared_ptr<basic_transport>;
 ```
 
-Shared pointer to a transport.
+  Shared pointer to a transport
+    .
 
----
+  -- -
 
-## Class: `zpt::network::layer`
+  ##Class
+  : `zpt::network::layer`
 
-Transport registry with content negotiation.
+  Transport registry with content negotiation.
 
-### Type Aliases
+  ## #Type Aliases
 
-```cpp
-using translate_from_func = std::function<zpt::json(std::istream&)>;
+```cpp using translate_from_func = std::function<zpt::json(std::istream&)>;
 using translate_to_func = std::function<std::string(std::ostream&, zpt::json)>;
 ```
 
-### Constructor
+  ## #Constructor
 
 ```cpp
-layer(zpt::json _global_config);
+  layer(zpt::json _global_config);
 ```
 
-### Transport Management
+  ## #Transport Management
 
-```cpp
-auto add(std::string const& _scheme, zpt::transport _transport) -> layer&;
+```cpp auto
+  add(std::string const& _scheme, zpt::transport _transport) -> layer&;
 auto get(std::string const& _scheme) const -> const zpt::transport;
 auto remove(std::string const& _scheme) -> layer&;
 auto clear() -> layer&;
 ```
 
-### Resolution
+  ## #Resolution
 
-```cpp
-auto resolve(std::string _uri) const -> zpt::transport;
+```cpp auto
+  resolve(std::string _uri) const -> zpt::transport;
 ```
 
 Returns the transport for a URI based on its scheme.
@@ -135,10 +138,9 @@ auto translate(std::istream& _io, std::string _mime = "*/*") const -> zpt::json;
 auto translate(std::ostream& _io, std::string _mime, zpt::json _content) const -> std::string;
 ```
 
-Translates content based on MIME type. Supported types:
-- `application/json` - JSON serialization
-- `application/xml` / `text/xml` - XML serialization
-- `*/*` / `text/plain` - Raw text
+    Translates content based on MIME type.Supported types : - `application /
+    json` -
+  JSON serialization - `application / xml` / `text / xml` - XML serialization - `*/*` / `text/plain` - Raw text
 
 ### Iteration
 
@@ -195,7 +197,7 @@ auto shutdown() -> engine&;
 ### `zpt::TRANSPORT_ENGINE`
 
 ```cpp
-auto TRANSPORT_ENGINE(zpt::json _config = nullptr) -> zpt::transports::engine&;
+auto TRANSPORT_ENGINE(zpt::json _config = nullptr) -> zpt::transports::engine::ptr;
 ```
 
 Returns the global transport engine instance.
@@ -222,7 +224,7 @@ class transport_event_init : public zpt::event_initialization {
 Event for receiving messages from streams.
 
 ```cpp
-receive(zpt::transports::engine& _engine, zpt::polling::ptr _polling, zpt::stream _stream);
+receive(zpt::transports::engine::ptr _engine, zpt::polling::ptr _polling, zpt::stream _stream);
 ```
 
 ### Class: `zpt::events::send`
@@ -396,9 +398,9 @@ UPnP/SSDP device discovery via multicast UDP.
 ### Registering Transports
 
 ```cpp
-#include <zapata/transport.h>
 #include <zapata/net/transport/http.h>
 #include <zapata/net/transport/websocket.h>
+#include <zapata/transport.h>
 
 auto config = zpt::json::object();
 auto& layer = zpt::TRANSPORT_LAYER(config);
@@ -413,17 +415,17 @@ layer.add("http", zpt::make_transport<zpt::net::transport::http>())
 ```cpp
 #include <zapata/transport/engine.h>
 
-auto& engine = zpt::TRANSPORT_ENGINE(config);
+auto engine = zpt::TRANSPORT_ENGINE(config);
 
 // Add a resolver for routing messages
-engine.add_resolver(my_resolver);
+engine->add_resolver(my_resolver);
 
 // Start accepting connections
 auto& server = zpt::HTTP_SERVER_SOCKET(8080);
 auto polling = zpt::STREAM_POLLING();
 
 polling->register_delegate([&](zpt::polling::ptr p, zpt::stream s) {
-    engine.dispatcher()->trigger<zpt::events::receive>(engine, p, s);
+    engine->dispatcher()->trigger<zpt::events::receive>(engine, p, s);
     return true;
 });
 
@@ -476,8 +478,8 @@ request->uri()["port"] = 80;
 request->uri()["path"] = "/v1/users";
 
 // Trigger call with response handler
-auto& engine = zpt::TRANSPORT_ENGINE();
-engine.dispatcher()->trigger<zpt::events::call<MyResponseHandler>>(resolver, request);
+auto engine = zpt::TRANSPORT_ENGINE();
+engine->dispatcher()->trigger<zpt::events::call<MyResponseHandler>>(resolver, request);
 ```
 
 ---

--- a/docs/examples/websocket-chat/README.md
+++ b/docs/examples/websocket-chat/README.md
@@ -18,7 +18,7 @@ auto main(int _argc, char* _argv[]) -> int {
     auto& boot = zpt::BOOT_ENGINE();
 
     // Store connected clients
-    auto clients = std::make_shared<std::vector<zpt::json>>();
+    auto clients = zpt::allocate_shared<std::vector<zpt::json>>();
 
     // Handle incoming chat messages
     boot.add_handler(zpt::Post, "/ws/chat",

--- a/docs/extending/custom-transport.md
+++ b/docs/extending/custom-transport.md
@@ -48,7 +48,7 @@ public:
 
 ```cpp
 // In your plugin initialization
-zpt::network::layer::add("myproto", std::make_shared<myproto::transport>());
+zpt::network::layer::add("myproto", zpt::allocate_shared<myproto::transport>());
 ```
 
 ## Step 3: Configure

--- a/engines/rest/include/zapata/rest/rest.h
+++ b/engines/rest/include/zapata/rest/rest.h
@@ -62,7 +62,7 @@ namespace rest {
  *     });
  *
  * // Add to transport engine
- * zpt::TRANSPORT_ENGINE(config).add_resolver(resolver);
+ * zpt::TRANSPORT_ENGINE(config)->add_resolver(resolver);
  * @endcode
  */
 class resolver_t : public zpt::events::resolver_t {

--- a/engines/rest/include/zapata/rest/services.h
+++ b/engines/rest/include/zapata/rest/services.h
@@ -60,6 +60,14 @@ class minion_hello : public zpt::events::process {
     auto operator()(zpt::events::dispatcher::ptr _dispatcher) -> zpt::events::state;
 };
 
+class minion_state : public zpt::events::process {
+  public:
+    using zpt::events::process::process;
+    ~minion_state() = default;
+    auto blocked() const -> bool;
+    auto operator()(zpt::events::dispatcher::ptr _dispatcher) -> zpt::events::state;
+};
+
 /**
  * @brief Event operation for listing registered services.
  *
@@ -79,6 +87,6 @@ class services_list : public zpt::events::process {
 namespace services {
 /** @brief Broadcasts service registration to connected nodes. */
 auto broadcast(std::string const& _path, zpt::json const& _config) -> void;
-}
+} // namespace services
 } // namespace rest
 } // namespace zpt

--- a/engines/rest/src/plugin.cpp
+++ b/engines/rest/src/plugin.cpp
@@ -40,7 +40,8 @@ extern "C" auto _zpt_load_(zpt::plugin&) -> void {
     zpt::REST_RESOLVER() //
       ->add<zpt::rest::minion_boot>(zpt::Notify, "/minions/boot")
       .add<zpt::rest::minion_shutdown>(zpt::Notify, "/minions/shutdown")
-      .add<zpt::rest::minion_hello>("/minions/hello");
+      .add<zpt::rest::minion_hello>("/minions/hello")
+      .add<zpt::rest::minion_state>("/minions/state");
 
     if (_config("transport")("default")->ok() && _config("upnp")->ok()) {
         zpt::rest::services::broadcast("/minions/boot", _config);

--- a/engines/rest/src/plugin.cpp
+++ b/engines/rest/src/plugin.cpp
@@ -29,7 +29,7 @@
 extern "C" auto _zpt_load_(zpt::plugin&) -> void {
     auto _config = zpt::GLOBAL_CONFIG();
     zpt::TRANSPORT_ENGINE() //
-      .add_resolver(zpt::REST_RESOLVER(_config));
+      ->add_resolver(zpt::REST_RESOLVER(_config));
 
     if (_config("rest")("prefix")->ok()) {
         _config["rest"]["prefix_path_len"] =

--- a/engines/rest/src/rest.cpp
+++ b/engines/rest/src/rest.cpp
@@ -152,6 +152,6 @@ auto zpt::rest::resolver_t::clear() -> zpt::rest::resolver_t& {
 }
 
 auto zpt::REST_RESOLVER(zpt::json _config) -> zpt::events::resolver {
-    static zpt::events::resolver _global = std::make_shared<zpt::rest::resolver_t>(_config);
+    static zpt::events::resolver _global = zpt::allocate_shared<zpt::rest::resolver_t>(_config);
     return _global;
 }

--- a/engines/rest/src/services.cpp
+++ b/engines/rest/src/services.cpp
@@ -102,6 +102,29 @@ auto zpt::rest::minion_hello::operator()(zpt::events::dispatcher::ptr _dispatche
     return zpt::events::abort;
 }
 
+auto zpt::rest::minion_state::blocked() const -> bool { return false; }
+
+auto zpt::rest::minion_state::operator()(zpt::events::dispatcher::ptr _dispatcher [[maybe_unused]])
+  -> zpt::events::state {
+    if (this->received()->performative() == zpt::Post ||
+        this->received()->performative() == zpt::Get) {
+        this //
+          ->to_send()
+          ->status(200)
+          .body() = { "memory",
+                      zpt::json::parse_json_str(zpt::MEM_POOL().to_string()),
+                      "dispatchers",
+                      { zpt::array, _dispatcher->get_state(), zpt::DISPATCHER()->get_state() } };
+        return zpt::events::finish;
+    }
+
+    this //
+      ->to_send()
+      ->status(405)
+      .body() = { "message", "Only GET allowed to use with `/services`" };
+    return zpt::events::abort;
+}
+
 auto zpt::rest::services_list::blocked() const -> bool { return false; }
 
 auto zpt::rest::services_list::operator()(zpt::events::dispatcher::ptr _dispatcher [[maybe_unused]])

--- a/engines/runtime/src/runtime.cpp
+++ b/engines/runtime/src/runtime.cpp
@@ -71,17 +71,13 @@ auto zpt::runtime::initialize(int _argc, char** _argv) -> void {
                _config("dispatcher")("limits")("max_consumer_threads")->ok()
                  ? _config("dispatcher")("limits")("max_consumer_threads")->integer()
                  : 1LL);
-    auto _producers = std::max(1LL,
-                               _config("transport")("limits")("max_consumer_threads")->ok()
-                                 ? _config("transport")("limits")("max_consumer_threads")->integer()
-                                 : 1LL);
-
-    zpt::MEM_POOL(_config("dispatcher")("limits")("max_memory")->ok()
-                    ? _config("dispatcher")("limits")("max_memory")->integer()
-                    : 0);
+    zpt::MEM_POOL() //
+      .max_size(_config("dispatcher")("limits")("max_memory")->ok()
+                  ? _config("dispatcher")("limits")("max_memory")->integer()
+                  : 0);
 
     zlog("Booting server PID " << zpt::log_pid, zpt::notice);
-    zpt::DISPATCHER(_consumers, _producers) //
+    zpt::DISPATCHER(_consumers, 10000) //
       ->start_consumers(_consumers);
     zpt::DISPATCHER() //
       ->trigger<zpt::system_event>(zpt::system_event_type::BOOTING);

--- a/engines/transport/include/zapata/transport/engine.h
+++ b/engines/transport/include/zapata/transport/engine.h
@@ -82,8 +82,8 @@ namespace events {
 class transport_event_init : public zpt::event_initialization {
   public:
     zpt::events::dispatcher::weak_ptr __dispatcher; ///< Event dispatcher
-    zpt::polling::ptr __polling{ nullptr };                    ///< I/O polling instance
-    zpt::stream __stream{ nullptr };                           ///< Source stream
+    zpt::polling::ptr __polling{ nullptr };         ///< I/O polling instance
+    zpt::stream __stream{ nullptr };                ///< Source stream
 };
 
 /**
@@ -353,7 +353,7 @@ class process_call_reply : public zpt::events::process {
  * @param _config Optional configuration (used only on first call).
  * @return Reference to the global transport engine.
  */
-auto TRANSPORT_ENGINE(zpt::json _config = nullptr) -> zpt::transports::engine&;
+auto TRANSPORT_ENGINE(zpt::json _config = zpt::undefined) -> zpt::transports::engine&;
 
 template<ProcessOperation T = zpt::events::process_call_reply>
 auto make_call(zpt::events::resolver _resolver, zpt::message _to_send) -> zpt::call_context::ptr;
@@ -452,7 +452,7 @@ auto zpt::events::call<T>::call_internally() -> call& {
     expect(_transport->has_capability(zpt::transport_capability::SYNCHRONOUS),
            "`call` only makes sense for synchronous protocols");
 
-    auto _stream = std::make_shared<zpt::event_stream>();
+    auto _stream = zpt::allocate_shared<zpt::event_stream>();
     _stream->transport("self");
 
     this->__to_send->headers()["Content-Type"] = "application/json";
@@ -487,7 +487,7 @@ auto zpt::events::call<T>::send_externally() -> call& {
 template<ProcessOperation T>
 auto zpt::make_call(zpt::events::resolver _resolver, zpt::message _to_send)
   -> zpt::call_context::ptr {
-    auto _context = std::make_shared<zpt::call_context>();
+    auto _context = zpt::allocate_shared<zpt::call_context>();
     zpt::TRANSPORT_ENGINE() //
       .dispatcher()
       ->trigger<zpt::events::call<T>>(_resolver, _context, _to_send);

--- a/engines/transport/include/zapata/transport/engine.h
+++ b/engines/transport/include/zapata/transport/engine.h
@@ -40,15 +40,17 @@ namespace transports {
  *
  * @par Example
  * @code
- * auto& engine = zpt::TRANSPORT_ENGINE(config);
- * engine.add_resolver(my_resolver);
+ * auto engine = zpt::TRANSPORT_ENGINE(config);
+ * engine->add_resolver(my_resolver);
  *
  * // Engine runs in background, processing incoming connections
- * engine.dispatcher()->trap();  // Wait for shutdown
+ * engine->dispatcher()->trap();  // Wait for shutdown
  * @endcode
  */
-class engine {
+class engine : public std::enable_shared_from_this<engine> {
   public:
+    using ptr = std::shared_ptr<engine>;
+
     /** @brief Constructs an engine with the given configuration. */
     engine(zpt::json _config);
     /** @brief Destructor. */
@@ -95,7 +97,7 @@ class transport_event_init : public zpt::event_initialization {
 class receive {
   public:
     /** @brief Constructs a receive event for the given engine, polling instance, and stream. */
-    receive(zpt::transports::engine& _engine, zpt::polling::ptr _polling, zpt::stream _stream);
+    receive(zpt::transports::engine::ptr _engine, zpt::polling::ptr _polling, zpt::stream _stream);
     receive(zpt::events::receive const& _rhs) = delete;
     receive(zpt::events::receive&& _rhs) = delete;
     /** @brief Destructor. */
@@ -121,7 +123,7 @@ class receive {
     auto operator()(zpt::events::dispatcher::ptr _dispatcher) -> zpt::events::state;
 
   protected:
-    zpt::transports::engine& __engine;
+    zpt::transports::engine::ptr __engine;
     zpt::polling::ptr __polling{ nullptr };
     zpt::stream __stream{ nullptr };
 };
@@ -353,7 +355,7 @@ class process_call_reply : public zpt::events::process {
  * @param _config Optional configuration (used only on first call).
  * @return Reference to the global transport engine.
  */
-auto TRANSPORT_ENGINE(zpt::json _config = zpt::undefined) -> zpt::transports::engine&;
+auto TRANSPORT_ENGINE(zpt::json _config = zpt::undefined) -> zpt::transports::engine::ptr;
 
 template<ProcessOperation T = zpt::events::process_call_reply>
 auto make_call(zpt::events::resolver _resolver, zpt::message _to_send) -> zpt::call_context::ptr;
@@ -489,7 +491,7 @@ auto zpt::make_call(zpt::events::resolver _resolver, zpt::message _to_send)
   -> zpt::call_context::ptr {
     auto _context = zpt::allocate_shared<zpt::call_context>();
     zpt::TRANSPORT_ENGINE() //
-      .dispatcher()
+      ->dispatcher()
       ->trigger<zpt::events::call<T>>(_resolver, _context, _to_send);
     return _context;
 }

--- a/engines/transport/src/engine.cpp
+++ b/engines/transport/src/engine.cpp
@@ -274,7 +274,7 @@ auto zpt::events::process::catch_error(zpt::failed_expectation const& _e,
 
 zpt::transports::engine::engine(zpt::json _config)
   : __configuration{ _config }
-  , __dispatcher{ std::make_shared<zpt::events::dispatcher>(
+  , __dispatcher{ zpt::allocate_shared<zpt::events::dispatcher>(
       "transport",
       _config("limits")("max_consumer_threads")->ok()
         ? _config("limits")("max_consumer_threads")->integer()
@@ -306,7 +306,7 @@ zpt::transports::engine::engine(zpt::json _config)
 #endif
           return true;
       });
-    auto _event_init = std::make_shared<zpt::events::transport_event_init>();
+    auto _event_init = zpt::allocate_shared<zpt::events::transport_event_init>();
     _event_init->__polling = zpt::STREAM_POLLING();
     _event_init->__dispatcher = this->__dispatcher;
     this

--- a/engines/transport/src/engine.cpp
+++ b/engines/transport/src/engine.cpp
@@ -41,7 +41,7 @@ auto report_error(T const& _e, zpt::stream _stream, zpt::polling::ptr _polling) 
 }
 } // namespace
 
-zpt::events::receive::receive(zpt::transports::engine& _engine,
+zpt::events::receive::receive(zpt::transports::engine::ptr _engine,
                               zpt::polling::ptr _polling,
                               zpt::stream _stream)
   : __engine{ _engine }
@@ -95,7 +95,7 @@ auto zpt::events::receive::operator()(zpt::events::dispatcher::ptr _dispatcher)
             !_dispatcher->is_in_shutdown()) {
 
             auto _events =
-              this->__engine.resolve(_received, [this, _dispatcher](zpt::event& _event) {
+              this->__engine->resolve(_received, [this, _dispatcher](zpt::event& _event) {
                   zpt::events::transport_event_init _init;
                   _init.__dispatcher = _dispatcher;
                   _init.__polling = this->__polling;
@@ -287,7 +287,8 @@ zpt::transports::engine::engine(zpt::json _config)
 #ifndef PROPAGATE_EXCEPTION
           try {
 #endif
-              this->__dispatcher->trigger<zpt::events::receive>(*this, _poll, _stream);
+              this->__dispatcher->trigger<zpt::events::receive>(
+                this->shared_from_this(), _poll, _stream);
               return true;
 #ifndef PROPAGATE_EXCEPTION
           }
@@ -359,7 +360,7 @@ auto zpt::events::process_call_reply::operator()(zpt::events::dispatcher::ptr _d
     return zpt::events::finish;
 }
 
-auto zpt::TRANSPORT_ENGINE(zpt::json _config) -> zpt::transports::engine& {
-    static zpt::transports::engine _global{ _config };
+auto zpt::TRANSPORT_ENGINE(zpt::json _config) -> zpt::transports::engine::ptr {
+    static auto _global = std::make_shared<zpt::transports::engine>(_config);
     return _global;
 }

--- a/engines/transport/src/engine.cpp
+++ b/engines/transport/src/engine.cpp
@@ -278,9 +278,6 @@ zpt::transports::engine::engine(zpt::json _config)
       "transport",
       _config("limits")("max_consumer_threads")->ok()
         ? _config("limits")("max_consumer_threads")->integer()
-        : 1,
-      _config("limits")("max_consumer_threads")->ok()
-        ? _config("limits")("max_consumer_threads")->integer()
         : 1) } {
     zpt::STREAM_POLLING() //
       ->register_delegate([this](zpt::polling::ptr _poll, zpt::stream _stream) -> bool {

--- a/engines/transport/src/plugin.cpp
+++ b/engines/transport/src/plugin.cpp
@@ -37,5 +37,5 @@ extern "C" auto _zpt_load_(zpt::plugin& _plugin) -> void {
 
 extern "C" auto _zpt_unload_(zpt::plugin&) -> void {
     zlog("Stopped multi-transport engine", zpt::info);
-    zpt::TRANSPORT_ENGINE().shutdown();
+    zpt::TRANSPORT_ENGINE()->shutdown();
 }

--- a/io/socket/include/zapata/net/socket/socket_stream.h
+++ b/io/socket/include/zapata/net/socket/socket_stream.h
@@ -201,13 +201,13 @@ class basic_socketstream : public std::basic_iostream<Char> {
     /** @brief Default constructor (unconnected). */
     basic_socketstream();
     /** @brief Wraps an existing TCP socket with address info. */
-    basic_socketstream(int s, zpt::sockaddrin_t& _address, bool _ssl, short _protocol);
+    basic_socketstream(int s, zpt::sockaddrin_t const& _address, bool _ssl, short _protocol);
     /** @brief Connects to a remote host. */
     basic_socketstream(std::string const& _host, std::uint16_t _port, bool _ssl, short _protocol);
     /** @brief Creates a UDP client socket. */
     basic_socketstream(bool _ssl, short _protocol);
     /** @brief Wraps an existing Unix domain socket. */
-    basic_socketstream(int s, zpt::sockaddrun_t& _address);
+    basic_socketstream(int s, zpt::sockaddrun_t const& _address);
     /** @brief Connects to a Unix domain socket by path. */
     basic_socketstream(std::string const& _path);
     basic_socketstream(const basic_socketstream&) = delete;
@@ -738,7 +738,7 @@ zpt::basic_socketstream<Char>::basic_socketstream()
 
 template<typename Char>
 zpt::basic_socketstream<Char>::basic_socketstream(int s,
-                                                  zpt::sockaddrin_t& _address,
+                                                  zpt::sockaddrin_t const& _address,
                                                   bool _ssl,
                                                   short _protocol)
   : __stream_type(&__buf)
@@ -773,7 +773,7 @@ zpt::basic_socketstream<Char>::basic_socketstream(bool _ssl, short _protocol)
 }
 
 template<typename Char>
-zpt::basic_socketstream<Char>::basic_socketstream(int s, zpt::sockaddrun_t& _address)
+zpt::basic_socketstream<Char>::basic_socketstream(int s, zpt::sockaddrun_t const& _address)
   : __stream_type(&__buf)
   , __is_error(false) {
     this->__buf.set_socket(s);

--- a/io/socket/src/socket_stream.cpp
+++ b/io/socket/src/socket_stream.cpp
@@ -61,13 +61,13 @@ auto zpt::is_multicast_address(std::string const& _ip) -> bool {
 }
 
 zpt::serversocketstream::serversocketstream()
-  : __underlying{ std::make_shared<zpt::basic_serversocketstream<char>>() } {}
+  : __underlying{ zpt::allocate_shared<zpt::basic_serversocketstream<char>>() } {}
 
 zpt::serversocketstream::serversocketstream(std::uint16_t _port)
-  : __underlying{ std::make_shared<zpt::basic_serversocketstream<char>>(_port) } {}
+  : __underlying{ zpt::allocate_shared<zpt::basic_serversocketstream<char>>(_port) } {}
 
 zpt::serversocketstream::serversocketstream(std::string const& _path)
-  : __underlying{ std::make_shared<zpt::basic_serversocketstream<char>>(_path) } {}
+  : __underlying{ zpt::allocate_shared<zpt::basic_serversocketstream<char>>(_path) } {}
 
 zpt::serversocketstream::serversocketstream(const zpt::serversocketstream& _rhs) { (*this) = _rhs; }
 
@@ -94,13 +94,13 @@ auto zpt::serversocketstream::operator*() -> zpt::basic_serversocketstream<char>
 }
 
 zpt::wserversocketstream::wserversocketstream()
-  : __underlying{ std::make_shared<zpt::basic_serversocketstream<wchar_t>>() } {}
+  : __underlying{ zpt::allocate_shared<zpt::basic_serversocketstream<wchar_t>>() } {}
 
 zpt::wserversocketstream::wserversocketstream(std::uint16_t _port)
-  : __underlying{ std::make_shared<zpt::basic_serversocketstream<wchar_t>>(_port) } {}
+  : __underlying{ zpt::allocate_shared<zpt::basic_serversocketstream<wchar_t>>(_port) } {}
 
 zpt::wserversocketstream::wserversocketstream(std::string const& _path)
-  : __underlying{ std::make_shared<zpt::basic_serversocketstream<wchar_t>>(_path) } {}
+  : __underlying{ zpt::allocate_shared<zpt::basic_serversocketstream<wchar_t>>(_path) } {}
 
 zpt::wserversocketstream::wserversocketstream(const zpt::wserversocketstream& _rhs) {
     (*this) = _rhs;

--- a/io/socket/src/test_server.cpp
+++ b/io/socket/src/test_server.cpp
@@ -2,18 +2,18 @@
 
 auto main(int argc, char* argv[]) -> int {
     if (argc > 2) {
-        std::unique_ptr<zpt::serversocketstream> _ssock{ nullptr };
+        zpt::allocator<zpt::serversocketstream>::unique_pointer _ssock{ nullptr };
         std::string _type{ argv[1] };
         if (_type == "-t") {
             std::istringstream _iss;
             _iss.str(std::string{ argv[2] });
             std::uint16_t _port{ 0 };
             _iss >> _port;
-            _ssock = std::make_unique<zpt::serversocketstream>(_port);
+            _ssock = zpt::allocate_unique<zpt::serversocketstream>(_port);
         }
         else if (_type == "-u") {
             std::string _path{ argv[2] };
-            _ssock = std::make_unique<zpt::serversocketstream>(_path);
+            _ssock = zpt::allocate_unique<zpt::serversocketstream>(_path);
         }
 
         do {

--- a/io/stream/include/zapata/streams/streams.h
+++ b/io/stream/include/zapata/streams/streams.h
@@ -302,7 +302,8 @@ auto zpt::basic_stream::set_peer(std::string const& _address, unsigned int _port
 
 template<typename T, typename... Args>
 auto zpt::make_stream(Args... _args) -> zpt::stream {
-    zpt::stream _to_return{ new zpt::basic_stream{ zpt::allocate_unique<T>(_args...) } };
+    zpt::stream _to_return{ new zpt::basic_stream{
+      zpt::allocate_unique<T>(std::forward<Args>(_args)...) } };
     if constexpr (std::is_convertible<T, int>::value) {
         (*_to_return) = static_cast<int>(static_cast<T&>(**_to_return));
     }

--- a/io/stream/include/zapata/streams/streams.h
+++ b/io/stream/include/zapata/streams/streams.h
@@ -39,6 +39,7 @@
 #include <memory>
 #include <sys/epoll.h>
 #include <systemd/sd-daemon.h>
+#include <zapata/allocator.h>
 #include <zapata/locks/spin_mutex.h>
 #include <zapata/text/convert.h>
 
@@ -87,9 +88,9 @@ class basic_stream : public std::enable_shared_from_this<basic_stream> {
     /** @brief Default constructor. */
     basic_stream() = default;
     /** @brief Constructs from an existing stream. */
-    basic_stream(std::ios& _rhs);
+    // basic_stream(std::ios& _rhs);
     /** @brief Constructs from a unique pointer to a stream. */
-    basic_stream(std::unique_ptr<std::iostream> _underlying);
+    basic_stream(zpt::allocator<std::iostream>::unique_pointer _underlying);
     basic_stream(basic_stream const& _rhs) = delete;
     basic_stream(basic_stream&& _rhs) = delete;
     /** @brief Destructor. Closes the stream. */
@@ -137,7 +138,7 @@ class basic_stream : public std::enable_shared_from_this<basic_stream> {
     virtual auto persistent() -> bool;
 
   protected:
-    std::unique_ptr<std::iostream> __underlying{ nullptr };
+    zpt::allocator<std::iostream>::unique_pointer __underlying{ nullptr };
     int __fd{ -1 };
     std::string __transport{ "" };
     std::string __uri{ "" };
@@ -301,7 +302,7 @@ auto zpt::basic_stream::set_peer(std::string const& _address, unsigned int _port
 
 template<typename T, typename... Args>
 auto zpt::make_stream(Args... _args) -> zpt::stream {
-    zpt::stream _to_return{ new zpt::basic_stream{ std::make_unique<T>(_args...) } };
+    zpt::stream _to_return{ new zpt::basic_stream{ zpt::allocate_unique<T>(_args...) } };
     if constexpr (std::is_convertible<T, int>::value) {
         (*_to_return) = static_cast<int>(static_cast<T&>(**_to_return));
     }

--- a/io/stream/src/streams.cpp
+++ b/io/stream/src/streams.cpp
@@ -29,15 +29,15 @@ namespace {
 constexpr std::uint64_t POLL_WAIT_TIMEOUT{ 100000 };
 }
 
-zpt::basic_stream::basic_stream(std::ios& _rhs)
-  : __underlying{ std::make_unique<std::stringstream>() }
-  , __fd{ -1 } {
-    this->__underlying->rdbuf(_rhs.rdbuf());
-    this->__underlying->exceptions(std::ios_base::failbit);
-}
+// zpt::basic_stream::basic_stream(std::ios& _rhs)
+//   : __underlying{ zpt::allocate_unique<std::stringstream>() }
+//   , __fd{ -1 } {
+//     this->__underlying->rdbuf(_rhs.rdbuf());
+//     this->__underlying->exceptions(std::ios_base::failbit);
+// }
 
-zpt::basic_stream::basic_stream(std::unique_ptr<std::iostream> _underlying)
-  : __underlying{ _underlying.release() }
+zpt::basic_stream::basic_stream(zpt::allocator<std::iostream>::unique_pointer _underlying)
+  : __underlying{ std::move(_underlying) }
   , __fd{ -1 } {
     this->__underlying->exceptions(std::ios_base::failbit);
 }
@@ -235,6 +235,6 @@ auto zpt::polling::shutdown() -> zpt::polling& {
 auto zpt::polling::is_in_shutdown() const -> bool { return this->__shutdown.load(); }
 
 auto zpt::STREAM_POLLING() -> zpt::polling::ptr {
-    static zpt::polling::ptr _global = std::make_shared<zpt::polling>();
+    static zpt::polling::ptr _global = zpt::allocate_shared<zpt::polling>();
     return _global;
 }

--- a/network/upnp/src/test.cpp
+++ b/network/upnp/src/test.cpp
@@ -41,7 +41,7 @@ auto main(int _argc, char* _argv[]) -> int {
               _config("bind")->string(), _config("port")->integer(), zpt::NO_SSL, IPPROTO_UDP);
             _stream->transport("upnp");
 
-            zpt::polling::ptr _polling = std::make_shared<zpt::polling>();
+            zpt::polling::ptr _polling = zpt::allocate_shared<zpt::polling>();
             _polling //
               ->register_delegate(
                 [&_transport](zpt::polling::ptr _poll, zpt::stream _stream) -> bool {

--- a/parsers/json/include/zapata/json/JSONClass.h
+++ b/parsers/json/include/zapata/json/JSONClass.h
@@ -74,6 +74,7 @@
 #include <unordered_map>
 #include <variant>
 #include <vector>
+#include <zapata/allocator.h>
 #include <zapata/base/expect.h>
 #include <zapata/log/log.h>
 #include <zapata/text/convert.h>
@@ -266,7 +267,7 @@ class json {
     /** @brief Constructs a null JSON value. */
     json(std::nullptr_t _rhs);
     /** @brief Constructs from a unique pointer to a JSON element. */
-    json(std::unique_ptr<zpt::JSONElementT> _target);
+    json(zpt::allocator<zpt::JSONElementT>::shared_pointer _target);
     /**
      * @brief Constructs from an initializer list.
      *
@@ -805,7 +806,7 @@ class JSONObjT {
     /** @brief Pushes a key (next push must be a value). */
     virtual auto push(std::string const& _name) -> zpt::JSONObjT&;
     /** @brief Pushes a value for the pending key. */
-    virtual auto push(std::unique_ptr<zpt::JSONElementT> _value) -> JSONObjT&;
+    virtual auto push(zpt::allocator<zpt::JSONElementT>::shared_pointer _value) -> JSONObjT&;
     virtual auto push(zpt::json const& _value) -> zpt::JSONObjT&;
 
     /** @brief Removes element by index or key. */
@@ -973,7 +974,7 @@ class JSONArrT {
     /** @name Modification */
     ///@{
     /** @brief Appends a value to the array. */
-    virtual auto push(std::unique_ptr<zpt::JSONElementT> _value) -> zpt::JSONArrT&;
+    virtual auto push(zpt::allocator<zpt::JSONElementT>::shared_pointer _value) -> zpt::JSONArrT&;
     virtual auto push(zpt::json const& _value) -> zpt::JSONArrT&;
 
     /** @brief Removes element by index. */
@@ -1921,7 +1922,7 @@ zpt::pretty::pretty(T _rhs) {
 /// Class `zpt::json` methods
 template<typename T>
 zpt::json::json(T const& _rhs)
-  : __underlying{ new zpt::JSONElementT{ _rhs } } {}
+  : __underlying{ zpt::allocate_shared<zpt::JSONElementT>(_rhs) } {}
 template<typename T>
 auto zpt::json::operator=(T const& _rhs) -> zpt::json& {
     (*this->__underlying.get()) = _rhs;
@@ -1979,47 +1980,47 @@ auto zpt::json::pretty(T _e) -> std::string {
 template<typename T>
 auto zpt::json::string(T _e) -> zpt::json {
     std::string _v(_e);
-    return zpt::json{ std::make_unique<zpt::JSONElementT>(_v) };
+    return zpt::json{ zpt::allocate_shared<zpt::JSONElementT>(_v) };
 }
 template<typename T>
 auto zpt::json::integer(T _e) -> zpt::json {
     long long int _v(_e);
-    return zpt::json{ std::make_unique<zpt::JSONElementT>(_v) };
+    return zpt::json{ zpt::allocate_shared<zpt::JSONElementT>(_v) };
 }
 template<typename T>
 auto zpt::json::uinteger(T _e) -> zpt::json {
     unsigned int _v(_e);
-    return zpt::json{ std::make_unique<zpt::JSONElementT>(_v) };
+    return zpt::json{ zpt::allocate_shared<zpt::JSONElementT>(_v) };
 }
 template<typename T>
 auto zpt::json::floating(T _e) -> zpt::json {
     double _v(_e);
-    return zpt::json{ std::make_unique<zpt::JSONElementT>(_v) };
+    return zpt::json{ zpt::allocate_shared<zpt::JSONElementT>(_v) };
 }
 template<typename T>
 auto zpt::json::ulong(T _e) -> zpt::json {
     size_t _v(_e);
-    return zpt::json{ std::make_unique<zpt::JSONElementT>(_v) };
+    return zpt::json{ zpt::allocate_shared<zpt::JSONElementT>(_v) };
 }
 template<typename T>
 auto zpt::json::boolean(T _e) -> zpt::json {
     bool _v(_e);
-    return zpt::json{ std::make_unique<zpt::JSONElementT>(_v) };
+    return zpt::json{ zpt::allocate_shared<zpt::JSONElementT>(_v) };
 }
 template<typename T>
 auto zpt::json::date(T _e) -> zpt::json {
     zpt::timestamp_t _v(_e);
-    return zpt::json{ std::make_unique<zpt::JSONElementT>(_v) };
+    return zpt::json{ zpt::allocate_shared<zpt::JSONElementT>(_v) };
 }
 template<typename T>
 auto zpt::json::lambda(T _e) -> zpt::json {
     zpt::lambda _v(_e);
-    return zpt::json{ std::make_unique<zpt::JSONElementT>(_v) };
+    return zpt::json{ zpt::allocate_shared<zpt::JSONElementT>(_v) };
 }
 template<typename T>
 auto zpt::json::regex(T _e) -> zpt::json {
     zpt::regex _v(_e);
-    return zpt::json{ std::make_unique<zpt::JSONElementT>(_v) };
+    return zpt::json{ zpt::allocate_shared<zpt::JSONElementT>(_v) };
 }
 
 /// Class `zpt::JSONObjT` methods

--- a/parsers/json/src/JSONArr.cpp
+++ b/parsers/json/src/JSONArr.cpp
@@ -30,7 +30,7 @@ zpt::JSONArrT::JSONArrT() {}
 
 zpt::JSONArrT::~JSONArrT() {}
 
-auto zpt::JSONArrT::push(std::unique_ptr<zpt::JSONElementT> _value) -> JSONArrT& {
+auto zpt::JSONArrT::push(zpt::allocator<zpt::JSONElementT>::shared_pointer _value) -> JSONArrT& {
     this->__underlying.push_back(zpt::json{ std::move(_value) });
     return (*this);
 }
@@ -353,7 +353,7 @@ auto zpt::JSONArrT::prettify(std::ostream& _out, uint _n_tabs) const -> JSONArrT
 
 /*JSON POINTER TO ARRAY*/
 zpt::JSONArr::JSONArr()
-  : __underlying{ std::make_shared<zpt::JSONArrT>() } {}
+  : __underlying{ zpt::allocate_shared<zpt::JSONArrT>() } {}
 
 zpt::JSONArr::JSONArr(const JSONArr& _rhs) { (*this) = _rhs; }
 

--- a/parsers/json/src/JSONLambda.cpp
+++ b/parsers/json/src/JSONLambda.cpp
@@ -12,7 +12,7 @@ zpt::JSONContext::~JSONContext() { this->__target = nullptr; }
 auto zpt::JSONContext::unpack() -> void* { return this->__target; }
 
 zpt::context::context(void* _target)
-  : __underlying{ std::make_shared<zpt::JSONContext>(_target) } {}
+  : __underlying{ zpt::allocate_shared<zpt::JSONContext>(_target) } {}
 
 zpt::context::~context() {}
 
@@ -75,7 +75,7 @@ auto zpt::JSONLambda::call(zpt::json _args, zpt::context _ctx) -> zpt::json {
 }
 
 zpt::lambda::lambda()
-  : std::shared_ptr<zpt::JSONLambda>(std::make_shared<zpt::JSONLambda>()) {}
+  : std::shared_ptr<zpt::JSONLambda>(zpt::allocate_shared<zpt::JSONLambda>()) {}
 
 zpt::lambda::lambda(std::shared_ptr<zpt::JSONLambda> _target)
   : std::shared_ptr<zpt::JSONLambda>(_target) {}

--- a/parsers/json/src/JSONObj.cpp
+++ b/parsers/json/src/JSONObj.cpp
@@ -40,7 +40,7 @@ auto zpt::JSONObjT::push(std::string const& _name) -> JSONObjT& {
     return (*this);
 }
 
-auto zpt::JSONObjT::push(std::unique_ptr<zpt::JSONElementT> _value) -> JSONObjT& {
+auto zpt::JSONObjT::push(zpt::allocator<zpt::JSONElementT>::shared_pointer _value) -> JSONObjT& {
     expect(this->__name.length() != 0, "you must pass a field name first");
     zpt::json _ref{ std::move(_value) };
     auto [_it, _inserted] = this->__underlying.insert(std::make_pair(this->__name, _ref));
@@ -389,7 +389,7 @@ auto zpt::JSONObjT::prettify(std::ostream& _out, uint _n_tabs) const -> zpt::JSO
 
 /*JSON POINTER TO OBJECT*/
 zpt::JSONObj::JSONObj()
-  : __underlying{ std::make_shared<JSONObjT>() } {}
+  : __underlying{ zpt::allocate_shared<JSONObjT>() } {}
 
 zpt::JSONObj::JSONObj(const JSONObj& _rhs) { (*this) = _rhs; }
 

--- a/parsers/json/src/JSONPtr.cpp
+++ b/parsers/json/src/JSONPtr.cpp
@@ -55,17 +55,17 @@ zpt::pretty::operator std::string() { return this->__underlying; }
 
 /*JSON POINTER TO ELEMENT*/
 zpt::json::json()
-  : __underlying{ std::make_shared<zpt::JSONElementT>() } {}
+  : __underlying{ zpt::allocate_shared<zpt::JSONElementT>() } {}
 
 zpt::json::json(std::nullptr_t)
-  : zpt::json{ zpt::JSUndefined } {}
+  : zpt::json(zpt::JSUndefined) {}
 
 zpt::json::json(const zpt::json& _rhs) { (*this) = _rhs; }
 
 zpt::json::json(zpt::json&& _rhs) { (*this) = _rhs; }
 
-zpt::json::json(std::unique_ptr<zpt::JSONElementT> _target)
-  : __underlying{ _target.release() } {}
+zpt::json::json(zpt::allocator<zpt::JSONElementT>::shared_pointer _target)
+  : __underlying{ std::move(_target) } {}
 
 zpt::json::json(std::initializer_list<zpt::json> _init) { (*this) = _init; }
 
@@ -112,7 +112,7 @@ auto zpt::json::operator=(std::initializer_list<zpt::json> _list) -> zpt::json& 
            "initializer list parameter doesn't seem either an array or an object");
 
     this->__underlying =
-      std::make_shared<zpt::JSONElementT>(_is_array ? zpt::JSArray : zpt::JSObject);
+      zpt::allocate_shared<zpt::JSONElementT>(_is_array ? zpt::JSArray : zpt::JSObject);
 
     size_t _idx{ 0 };
     for (auto _element : _list) {
@@ -159,7 +159,7 @@ auto zpt::json::operator!=(std::nullptr_t) const -> bool {
 }
 
 auto zpt::json::operator<<(std::initializer_list<zpt::json> _in) -> zpt::json& {
-    (*this->__underlying.get()) << zpt::json{ _in };
+    (*this->__underlying.get()) << zpt::json(_in);
     return (*this);
 }
 
@@ -254,39 +254,39 @@ zpt::json::operator std::regex&() const {
 }
 
 auto zpt::json::operator+(std::initializer_list<zpt::json> _rhs) const -> zpt::json {
-    return this->operator+(zpt::json{ _rhs });
+    return this->operator+(zpt::json(_rhs));
 }
 
 auto zpt::json::operator+=(std::initializer_list<zpt::json> _rhs) -> zpt::json& {
-    return this->operator+=(zpt::json{ _rhs });
+    return this->operator+=(zpt::json(_rhs));
 }
 
 auto zpt::json::operator-(std::initializer_list<zpt::json> _rhs) const -> zpt::json {
-    return this->operator-(zpt::json{ _rhs });
+    return this->operator-(zpt::json(_rhs));
 }
 
 auto zpt::json::operator-=(std::initializer_list<zpt::json> _rhs) -> zpt::json& {
-    return this->operator-=(zpt::json{ _rhs });
+    return this->operator-=(zpt::json(_rhs));
 }
 
 auto zpt::json::operator/(std::initializer_list<zpt::json> _rhs) const -> zpt::json {
-    return this->operator/(zpt::json{ _rhs });
+    return this->operator/(zpt::json(_rhs));
 }
 
 auto zpt::json::operator|(std::initializer_list<zpt::json> _rhs) const -> zpt::json {
-    return this->operator|(zpt::json{ _rhs });
+    return this->operator|(zpt::json(_rhs));
 }
 
 auto zpt::json::operator|=(std::initializer_list<zpt::json> _rhs) -> json& {
-    return this->operator|=(zpt::json{ _rhs });
+    return this->operator|=(zpt::json(_rhs));
 }
 
 auto zpt::json::operator&(std::initializer_list<zpt::json> _rhs) const -> json {
-    return this->operator&(zpt::json{ _rhs });
+    return this->operator&(zpt::json(_rhs));
 }
 
 auto zpt::json::operator&=(std::initializer_list<zpt::json> _rhs) -> json& {
-    return this->operator&=(zpt::json{ _rhs });
+    return this->operator&=(zpt::json(_rhs));
 }
 
 auto zpt::json::operator+(zpt::json _rhs) const -> zpt::json {
@@ -322,8 +322,8 @@ auto zpt::json::operator+(zpt::json _rhs) const -> zpt::json {
                 return _lhs;
             }
             else {
-                return zpt::json{ this->__underlying->string() +
-                                  static_cast<std::string>(_rhs->string()) };
+                return zpt::json(this->__underlying->string() +
+                                 static_cast<std::string>(_rhs->string()));
             }
         }
         case zpt::JSInteger: {
@@ -332,7 +332,7 @@ auto zpt::json::operator+(zpt::json _rhs) const -> zpt::json {
                 for (auto [_idx, _key, _e] : _rhs) { _lhs << ((*this) + _e); }
                 return _lhs;
             }
-            else { return zpt::json{ this->__underlying->integer() + _rhs->number() }; }
+            else { return zpt::json(this->__underlying->integer() + _rhs->number()); }
         }
         case zpt::JSDouble: {
             if (_rhs->type() == zpt::JSArray) {
@@ -340,7 +340,7 @@ auto zpt::json::operator+(zpt::json _rhs) const -> zpt::json {
                 for (auto [_idx, _key, _e] : _rhs) { _lhs << ((*this) + _e); }
                 return _lhs;
             }
-            else { return zpt::json{ this->__underlying->floating() + _rhs->number() }; }
+            else { return zpt::json(this->__underlying->floating() + _rhs->number()); }
         }
         case zpt::JSBoolean: {
             if (_rhs->type() == zpt::JSArray) {
@@ -348,7 +348,7 @@ auto zpt::json::operator+(zpt::json _rhs) const -> zpt::json {
                 for (auto [_idx, _key, _e] : _rhs) { _lhs << ((*this) + _e); }
                 return _lhs;
             }
-            else { return zpt::json{ this->__underlying->boolean() || _rhs->number() }; }
+            else { return zpt::json(this->__underlying->boolean() || _rhs->number()); }
         }
         case zpt::JSUndefined:
         case zpt::JSNil: {
@@ -361,8 +361,8 @@ auto zpt::json::operator+(zpt::json _rhs) const -> zpt::json {
                 return _lhs;
             }
             else {
-                return zpt::json{ static_cast<zpt::timestamp_t>(this->__underlying->date() +
-                                                                _rhs->number()) };
+                return zpt::json(
+                  static_cast<zpt::timestamp_t>(this->__underlying->date() + _rhs->number()));
             }
         }
         case zpt::JSLambda: {
@@ -462,7 +462,7 @@ auto zpt::json::operator-(zpt::json _rhs) const -> zpt::json {
                 while ((_idx = _lhs.find(_rhs_str, _idx)) != std::string::npos) {
                     _lhs.erase(_idx, _rhs_str.length());
                 }
-                return zpt::json{ _lhs };
+                return zpt::json(_lhs);
             }
         }
         case zpt::JSInteger: {
@@ -471,7 +471,7 @@ auto zpt::json::operator-(zpt::json _rhs) const -> zpt::json {
                 for (auto [_idx, _key, _e] : _rhs) { _lhs << ((*this) - _e); }
                 return _lhs;
             }
-            else { return zpt::json{ this->__underlying->integer() - _rhs->number() }; }
+            else { return zpt::json(this->__underlying->integer() - _rhs->number()); }
         }
         case zpt::JSDouble: {
             if (_rhs->type() == zpt::JSArray) {
@@ -479,7 +479,7 @@ auto zpt::json::operator-(zpt::json _rhs) const -> zpt::json {
                 for (auto [_idx, _key, _e] : _rhs) { _lhs << ((*this) - _e); }
                 return _lhs;
             }
-            else { return zpt::json{ this->__underlying->floating() - _rhs->number() }; }
+            else { return zpt::json(this->__underlying->floating() - _rhs->number()); }
         }
         case zpt::JSBoolean: {
             if (_rhs->type() == zpt::JSArray) {
@@ -487,7 +487,7 @@ auto zpt::json::operator-(zpt::json _rhs) const -> zpt::json {
                 for (auto [_idx, _key, _e] : _rhs) { _lhs << ((*this) - _e); }
                 return _lhs;
             }
-            else { return zpt::json{ this->__underlying->boolean() && _rhs->number() }; }
+            else { return zpt::json(this->__underlying->boolean() && _rhs->number()); }
         }
         case zpt::JSUndefined:
         case zpt::JSNil: {
@@ -499,7 +499,7 @@ auto zpt::json::operator-(zpt::json _rhs) const -> zpt::json {
                 for (auto [_idx, _key, _e] : _rhs) { _lhs << ((*this) - _e); }
                 return _lhs;
             }
-            else { return zpt::json{ this->__underlying->date() - _rhs->number() }; }
+            else { return zpt::json(this->__underlying->date() - _rhs->number()); }
         }
         case zpt::JSLambda: {
             return zpt::undefined;
@@ -599,7 +599,7 @@ auto zpt::json::operator/(zpt::json _rhs) const -> zpt::json {
                 while ((_idx = _lhs.find(_rhs_str, _idx)) != std::string::npos) {
                     _lhs.erase(_idx, _rhs_str.length());
                 }
-                return zpt::json{ _lhs };
+                return zpt::json(_lhs);
             }
         }
         case zpt::JSInteger: {
@@ -608,7 +608,7 @@ auto zpt::json::operator/(zpt::json _rhs) const -> zpt::json {
                 for (auto [_idx, _key, _e] : _rhs) { _lhs << ((*this) / _e); }
                 return _lhs;
             }
-            else { return zpt::json{ this->__underlying->integer() / _rhs->number() }; }
+            else { return zpt::json(this->__underlying->integer() / _rhs->number()); }
         }
         case zpt::JSDouble: {
             if (_rhs->type() == zpt::JSArray) {
@@ -616,7 +616,7 @@ auto zpt::json::operator/(zpt::json _rhs) const -> zpt::json {
                 for (auto [_idx, _key, _e] : _rhs) { _lhs << ((*this) / _e); }
                 return _lhs;
             }
-            else { return zpt::json{ this->__underlying->floating() / _rhs->number() }; }
+            else { return zpt::json(this->__underlying->floating() / _rhs->number()); }
         }
         case zpt::JSBoolean: {
             if (_rhs->type() == zpt::JSArray) {
@@ -624,7 +624,7 @@ auto zpt::json::operator/(zpt::json _rhs) const -> zpt::json {
                 for (auto [_idx, _key, _e] : _rhs) { _lhs << ((*this) / _e); }
                 return _lhs;
             }
-            else { return zpt::json{ this->__underlying->boolean() / _rhs->number() }; }
+            else { return zpt::json(this->__underlying->boolean() / _rhs->number()); }
         }
         case zpt::JSUndefined:
         case zpt::JSNil: {
@@ -636,7 +636,7 @@ auto zpt::json::operator/(zpt::json _rhs) const -> zpt::json {
                 for (auto [_idx, _key, _e] : _rhs) { _lhs << ((*this) / _e); }
                 return _lhs;
             }
-            else { return zpt::json{ this->__underlying->date() / _rhs->number() }; }
+            else { return zpt::json(this->__underlying->date() / _rhs->number()); }
         }
         case zpt::JSLambda: {
             return zpt::undefined;
@@ -660,25 +660,25 @@ auto zpt::json::operator|(zpt::json _rhs) const -> zpt::json {
         }
         case zpt::JSString: {
             if (_rhs->type() == zpt::JSString) {
-                return zpt::json{ this->__underlying->string() + _rhs->string() };
+                return zpt::json(this->__underlying->string() + _rhs->string());
             }
             else {
-                return zpt::json{ this->__underlying->string() + static_cast<std::string>(_rhs) };
+                return zpt::json(this->__underlying->string() + static_cast<std::string>(_rhs));
             }
         }
         case zpt::JSInteger: {
-            return zpt::json{ this->__underlying->integer() | static_cast<long>(_rhs) };
+            return zpt::json(this->__underlying->integer() | static_cast<long>(_rhs));
         }
         case zpt::JSDouble: {
-            return zpt::json{ static_cast<unsigned long long>(*this) |
-                              static_cast<unsigned long long>(_rhs) };
+            return zpt::json(static_cast<unsigned long long>(*this) |
+                             static_cast<unsigned long long>(_rhs));
         }
         case zpt::JSBoolean: {
-            return zpt::json{ this->__underlying->boolean() | static_cast<bool>(_rhs) };
+            return zpt::json(this->__underlying->boolean() | static_cast<bool>(_rhs));
         }
         case zpt::JSDate: {
-            return zpt::json{ static_cast<unsigned long long>(*this) |
-                              static_cast<unsigned long long>(_rhs) };
+            return zpt::json(static_cast<unsigned long long>(*this) |
+                             static_cast<unsigned long long>(_rhs));
         }
         case zpt::JSUndefined:
         case zpt::JSNil:
@@ -764,21 +764,21 @@ auto zpt::json::operator&(zpt::json _rhs) const -> zpt::json {
                                       _rhs_str.end(),
                                       std::back_inserter(_lhs));
             }
-            return zpt::json{ _lhs };
+            return zpt::json(_lhs);
         }
         case zpt::JSInteger: {
-            return zpt::json{ this->__underlying->integer() & static_cast<long>(_rhs) };
+            return zpt::json(this->__underlying->integer() & static_cast<long>(_rhs));
         }
         case zpt::JSDouble: {
-            return zpt::json{ static_cast<unsigned long long>(*this) &
-                              static_cast<unsigned long long>(_rhs) };
+            return zpt::json(static_cast<unsigned long long>(*this) &
+                             static_cast<unsigned long long>(_rhs));
         }
         case zpt::JSBoolean: {
-            return zpt::json{ this->__underlying->boolean() & static_cast<bool>(_rhs) };
+            return zpt::json(this->__underlying->boolean() & static_cast<bool>(_rhs));
         }
         case zpt::JSDate: {
-            return zpt::json{ static_cast<unsigned long long>(*this) &
-                              static_cast<unsigned long long>(_rhs) };
+            return zpt::json(static_cast<unsigned long long>(*this) &
+                             static_cast<unsigned long long>(_rhs));
         }
         case zpt::JSUndefined:
         case zpt::JSNil:
@@ -1004,30 +1004,28 @@ auto zpt::json::parse_json_str(std::string const& _in) -> zpt::json {
 auto zpt::json::to_unicode(std::string& _str) -> void { zpt::utf8::encode(_str, '"'); }
 
 auto zpt::json::object() -> zpt::json {
-    zpt::JSONObj _empty;
-    return zpt::json{ std::make_unique<zpt::JSONElementT>(_empty) };
+    return zpt::json(zpt::allocate_shared<zpt::JSONElementT>(zpt::JSObject));
 }
 
 auto zpt::json::array() -> zpt::json {
-    zpt::JSONArr _empty;
-    return zpt::json{ std::make_unique<zpt::JSONElementT>(_empty) };
+    return zpt::json(zpt::allocate_shared<zpt::JSONElementT>(zpt::JSArray));
 }
 
 auto zpt::json::date(std::string const& _e) -> zpt::json {
     zpt::timestamp_t _v(zpt::timestamp(_e));
-    return zpt::json{ std::make_unique<zpt::JSONElementT>(_v) };
+    return zpt::json(zpt::allocate_shared<zpt::JSONElementT>(_v));
 }
 
 auto zpt::json::date() -> zpt::json {
     zpt::timestamp_t _v((zpt::timestamp_t)std::chrono::duration_cast<std::chrono::milliseconds>(
                           std::chrono::system_clock::now().time_since_epoch())
                           .count());
-    return zpt::json{ std::make_unique<zpt::JSONElementT>(_v) };
+    return zpt::json(zpt::allocate_shared<zpt::JSONElementT>(_v));
 }
 
 auto zpt::json::lambda(std::string const& _name, unsigned short _n_args) -> zpt::json {
     zpt::lambda _v(_name, _n_args);
-    return zpt::json{ std::make_unique<zpt::JSONElementT>(_v) };
+    return zpt::json(zpt::allocate_shared<zpt::JSONElementT>(_v));
 }
 
 auto zpt::json::type_of(std::string const&) -> zpt::JSONType { return zpt::JSString; }

--- a/parsers/json/src/JSONRegex.cpp
+++ b/parsers/json/src/JSONRegex.cpp
@@ -35,7 +35,7 @@ zpt::JSONRegex::JSONRegex(JSONRegex&& _rhs) { (*this) = _rhs; }
 
 zpt::JSONRegex::JSONRegex(std::string const& _target)
   : __underlying_original{ _target }
-  , __underlying{ std::make_shared<std::regex>(_target) } {}
+  , __underlying{ zpt::allocate_shared<std::regex>(_target) } {}
 
 zpt::JSONRegex::~JSONRegex() {}
 

--- a/parsers/json/src/test.cpp
+++ b/parsers/json/src/test.cpp
@@ -69,8 +69,9 @@ auto test_json_init() -> int {
 
 int main(int argc, char* argv[]) {
     if (argc > 1) {
-        zpt::json _parameter_config{ "--print",
-                                     { "options", { zpt::array, "optional", "single" } } };
+        zpt::json _parameter_config{
+            "--print", { "type", "string", "options", { zpt::array, "optional", "single" } }
+        };
         auto _parameters = zpt::parameters::parse(argc, argv, _parameter_config);
         zpt::parameters::verify(_parameters, _parameter_config);
 

--- a/storage/mysqlx/include/zapata/mysqlx/translate.h
+++ b/storage/mysqlx/include/zapata/mysqlx/translate.h
@@ -44,7 +44,7 @@ namespace mysqlx {
  */
 class result_set_metadata {
   public:
-    std::unique_ptr<MYSQL_BIND[]> __bind{ nullptr };
+    zpt::allocator<MYSQL_BIND>::array_pointer __bind{ nullptr };
     size_t __column_count{ 0 };
 
     result_set_metadata(MYSQL_STMT* _statement);

--- a/storage/mysqlx/src/connector.cpp
+++ b/storage/mysqlx/src/connector.cpp
@@ -21,8 +21,8 @@
 */
 
 #include <algorithm>
-#include <zapata/uuid.h>
 #include <zapata/mysqlx/connector.h>
+#include <zapata/uuid.h>
 
 auto zpt::storage::mysqlx::mysql_deinit::operator()(MYSQL* _to_dispose) const -> void {
     mysql_close(_to_dispose);

--- a/storage/mysqlx/src/translate.cpp
+++ b/storage/mysqlx/src/translate.cpp
@@ -29,7 +29,7 @@ zpt::storage::mysqlx::result_set_metadata::result_set_metadata(MYSQL_STMT* _stat
         this->__metadata = mysql_stmt_result_metadata(_statement);
         if (this->__metadata != nullptr) {
             this->__column_count = mysql_num_fields(this->__metadata);
-            this->__bind = std::make_unique<MYSQL_BIND[]>(this->__column_count);
+            this->__bind = zpt::allocate_array<MYSQL_BIND>(this->__column_count);
 
             for (size_t _idx = 0; _idx != this->__column_count; ++_idx) {
                 auto _col = mysql_fetch_field_direct(this->__metadata, _idx);


### PR DESCRIPTION
Added custom allocator:

- Introduced `zpt::allocate_shared`, `zpt::allocate_unique` and `zpt::allocate_array` to construct and initialize shared and unique pointer while using `zpt::allocator`.
- Replaced usage of `std::make_shared/unique` with custom allocator constructors.
- Added warning upon custom allocator disposal if there is any still remaining allocated memory.
- Introduces `/minions/state` endpoint to retrieve the minion's internal state (for now, allocated memory and dispatchers state).