### PR TITLE
Event stream can only be disposed after reply is received

### DIFF
--- a/io/stream/include/zapata/streams/event_stream.h
+++ b/io/stream/include/zapata/streams/event_stream.h
@@ -67,5 +67,6 @@ class event_stream : public basic_stream {
 
   private:
     std::any __content;
+    unsigned short __reads{ 0 };
 };
 } // namespace zpt

--- a/io/stream/src/event_stream.cpp
+++ b/io/stream/src/event_stream.cpp
@@ -37,6 +37,7 @@ auto zpt::event_stream::read_without_io(std::any& _out) -> zpt::event_stream& {
     _out = this->__content;
     std::uint64_t _val;
     eventfd_read(this->__fd, &_val);
+    ++this->__reads;
     return (*this);
 }
 
@@ -46,4 +47,4 @@ auto zpt::event_stream::write_without_io(std::any const& _in) -> zpt::event_stre
     return (*this);
 }
 
-auto zpt::event_stream::persistent() -> bool { return false; }
+auto zpt::event_stream::persistent() -> bool { return this->__reads != 2; }

--- a/io/stream/src/streams.cpp
+++ b/io/stream/src/streams.cpp
@@ -130,10 +130,10 @@ auto zpt::polling::mute(zpt::stream _stream) -> zpt::polling& {
 
 auto zpt::polling::unmute(zpt::stream _stream) -> zpt::polling& {
     if (!_stream->__muted) { return (*this); }
-    // if (!_stream->persistent() && _stream->state() == zpt::stream_state::IDLE) {
-    //     this->erase(_stream);
-    //     return (*this);
-    // }
+    if (!_stream->persistent() && _stream->state() == zpt::stream_state::IDLE) {
+        this->erase(_stream);
+        return (*this);
+    }
 
     zpt::epoll_event_t _new_event;
     _new_event.events = EPOLLIN | EPOLLPRI | EPOLLERR | EPOLLHUP | EPOLLRDHUP;

--- a/io/stream/src/streams.cpp
+++ b/io/stream/src/streams.cpp
@@ -130,10 +130,10 @@ auto zpt::polling::mute(zpt::stream _stream) -> zpt::polling& {
 
 auto zpt::polling::unmute(zpt::stream _stream) -> zpt::polling& {
     if (!_stream->__muted) { return (*this); }
-    if (!_stream->persistent() && _stream->state() == zpt::stream_state::IDLE) {
-        this->erase(_stream);
-        return (*this);
-    }
+    // if (!_stream->persistent() && _stream->state() == zpt::stream_state::IDLE) {
+    //     this->erase(_stream);
+    //     return (*this);
+    // }
 
     zpt::epoll_event_t _new_event;
     _new_event.events = EPOLLIN | EPOLLPRI | EPOLLERR | EPOLLHUP | EPOLLRDHUP;

--- a/network/transport/src/transport.cpp
+++ b/network/transport/src/transport.cpp
@@ -43,7 +43,7 @@ auto zpt::basic_transport::receive(zpt::stream _stream) const -> zpt::message {
         }
     }
     else { _to_return = this->process_incoming_request(_stream); }
-    zlog("Received '" << _stream->transport() << "' message: \n" << _to_return, zpt::trace);
+    zlog("Received message via '" << _stream->uri() << "': \n" << _to_return, zpt::trace);
     return _to_return;
 }
 
@@ -57,7 +57,7 @@ auto zpt::basic_transport::send(zpt::stream _stream, zpt::message _to_send) cons
                  _stream->state() == zpt::stream_state::ERRORING_OUT,
                "Stream not in a valid state for sending");
     }
-    zlog("Sending '" << _stream->transport() << "' message: \n" << _to_send, zpt::trace);
+    zlog("Sending message via '" << _stream->uri() << "' : \n" << _to_send, zpt::trace);
 
     _stream->write<zpt::message>(_to_send);
 


### PR DESCRIPTION
Identified race-condition in event-stream:

- The event-stream must only be cleared from the poll and disposed after the
  final reply is received.
- Counter added to `zpt::event_stream` in order to keep track of the replies
  processed by the stream and change the persistence flag accordingly.
