### PR TITLE
SSL request not passing the correct hostname to context

### DIFF
--- a/io/socket/include/zapata/net/socket/socket_stream.h
+++ b/io/socket/include/zapata/net/socket/socket_stream.h
@@ -982,7 +982,19 @@ auto zpt::basic_socketstream<Char>::open(std::string const& _path) -> bool {
 template<typename Char>
 auto zpt::basic_socketstream<Char>::open_ip() -> bool {
     auto& _in_address = reinterpret_cast<zpt::sockaddrin_t&>(this->__buf.address());
-    _in_address.sin_addr.s_addr = inet_addr(this->__buf.host().data());
+    in_addr_t _addr = inet_addr(this->__buf.host().data());
+    if (_addr == INADDR_NONE) {
+        addrinfo _hints{};
+        _hints.ai_family = AF_INET;
+        _hints.ai_socktype = SOCK_STREAM;
+        addrinfo* _results = nullptr;
+        if (getaddrinfo(this->__buf.host().data(), nullptr, &_hints, &_results) == 0 &&
+            _results != nullptr) {
+            _addr = reinterpret_cast<sockaddr_in*>(_results->ai_addr)->sin_addr.s_addr;
+            freeaddrinfo(_results);
+        }
+    }
+    _in_address.sin_addr.s_addr = _addr;
 
     auto _sd = ::socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
     if (::connect(_sd, &this->__buf.address(), sizeof this->__buf.address()) < 0) {
@@ -1034,7 +1046,19 @@ auto zpt::basic_socketstream<Char>::open_udp() -> bool {
 template<typename Char>
 auto zpt::basic_socketstream<Char>::open_ssl() -> bool {
     auto& _in_address = reinterpret_cast<zpt::sockaddrin_t&>(this->__buf.address());
-    _in_address.sin_addr.s_addr = inet_addr(this->__buf.host().data());
+    in_addr_t _addr = inet_addr(this->__buf.host().data());
+    if (_addr == INADDR_NONE) {
+        addrinfo _hints{};
+        _hints.ai_family = AF_INET;
+        _hints.ai_socktype = SOCK_STREAM;
+        addrinfo* _results = nullptr;
+        if (getaddrinfo(this->__buf.host().data(), nullptr, &_hints, &_results) == 0 &&
+            _results != nullptr) {
+            _addr = reinterpret_cast<sockaddr_in*>(_results->ai_addr)->sin_addr.s_addr;
+            freeaddrinfo(_results);
+        }
+    }
+    _in_address.sin_addr.s_addr = _addr;
 
     auto _sd = ::socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
     if (::connect(_sd,

--- a/network/http/src/retrieve.cpp
+++ b/network/http/src/retrieve.cpp
@@ -1,5 +1,4 @@
 #include <arpa/inet.h>
-#include <iostream>
 #include <netdb.h>
 #include <string>
 #include <sys/socket.h>
@@ -13,22 +12,18 @@ auto zpt::http::retrieve(zpt::message _to_send) -> zpt::message {
 
     auto _scheme = _to_send->uri()("scheme")->string();
     auto _use_ssl = (_scheme == "https");
-    auto _ips = zpt::http::resolve(_to_send->uri()("domain")->string());
+    auto _domain = _to_send->uri()("domain")->string();
 
-    for (auto [_, __, _ip] : _ips("ipv4")) {
-        auto _stream = zpt::make_stream<zpt::socketstream>(
-          _ip->string(), _use_ssl ? 443 : 80, _use_ssl, IPPROTO_TCP);
+    auto _stream = zpt::make_stream<zpt::socketstream>(
+      _domain, _use_ssl ? 443 : 80, _use_ssl, IPPROTO_TCP);
 
-        _stream //
-          ->write<zpt::message>(_to_send);
+    _stream //
+      ->write<zpt::message>(_to_send);
 
-        auto _reply = zpt::allocate_message<zpt::http::basic_reply>();
-        (*_stream) >> std::noskipws >> _reply;
+    auto _reply = zpt::allocate_message<zpt::http::basic_reply>();
+    (*_stream) >> std::noskipws >> _reply;
 
-        if (_reply->status() == 421) { continue; }
-        return _reply;
-    }
-    expect(false, "couldn't retrieve target document with the following IPs: " << _ips);
+    return _reply;
 }
 
 auto zpt::http::resolve(std::string const& _domain) -> zpt::json {

--- a/network/http/src/retrieve.cpp
+++ b/network/http/src/retrieve.cpp
@@ -9,19 +9,26 @@
 #include <zapata/net/socket/socket_stream.h>
 
 auto zpt::http::retrieve(zpt::message _to_send) -> zpt::message {
+    _to_send->headers()["Cache-Control"] = "no-store";
+
     auto _scheme = _to_send->uri()("scheme")->string();
     auto _use_ssl = (_scheme == "https");
-    auto _ip = zpt::http::resolve(_to_send->uri()("domain")->string());
-    auto _stream = zpt::make_stream<zpt::socketstream>(
-      _ip("ip4")->string(), _use_ssl ? 443 : 80, _use_ssl, IPPROTO_TCP);
+    auto _ips = zpt::http::resolve(_to_send->uri()("domain")->string());
 
-    _stream //
-      ->write<zpt::message>(_to_send);
+    for (auto [_, __, _ip] : _ips("ipv4")) {
+        auto _stream = zpt::make_stream<zpt::socketstream>(
+          _ip->string(), _use_ssl ? 443 : 80, _use_ssl, IPPROTO_TCP);
 
-    auto _reply = zpt::allocate_message<zpt::http::basic_reply>();
-    (*_stream) >> std::noskipws >> _reply;
+        _stream //
+          ->write<zpt::message>(_to_send);
 
-    return _reply;
+        auto _reply = zpt::allocate_message<zpt::http::basic_reply>();
+        (*_stream) >> std::noskipws >> _reply;
+
+        if (_reply->status() == 421) { continue; }
+        return _reply;
+    }
+    expect(false, "couldn't retrieve target document with the following IPs: " << _ips);
 }
 
 auto zpt::http::resolve(std::string const& _domain) -> zpt::json {
@@ -33,20 +40,19 @@ auto zpt::http::resolve(std::string const& _domain) -> zpt::json {
     int _err = getaddrinfo(_domain.c_str(), nullptr, &_hints, &_results);
     expect(_err == 0, "getaddrinfo error: " << gai_strerror(_err));
 
-    auto _return = zpt::json::object();
+    zpt::json _return{ "ipv4", zpt::json::array(), "ipv6", zpt::json::array() };
     for (addrinfo* _r = _results; _r != nullptr; _r = _r->ai_next) {
-
         if (_r->ai_family == AF_INET) {
             char _ip[INET_ADDRSTRLEN] = { 0 };
             auto* _addr = reinterpret_cast<sockaddr_in*>(_r->ai_addr);
             inet_ntop(AF_INET, &_addr->sin_addr, _ip, sizeof(_ip));
-            _return << "ip4" << std::string{ _ip, sizeof(_ip) };
+            _return["ipv4"] << std::string{ _ip, sizeof(_ip) };
         }
         else if (_r->ai_family == AF_INET6) {
             char _ip[INET6_ADDRSTRLEN] = { 0 };
             auto* _addr = reinterpret_cast<sockaddr_in6*>(_r->ai_addr);
             inet_ntop(AF_INET6, &_addr->sin6_addr, _ip, sizeof(_ip));
-            _return << "ip6" << std::string{ _ip, sizeof(_ip) };
+            _return["ipv6"] << std::string{ _ip, sizeof(_ip) };
         }
     }
 

--- a/parsers/http/src/HTTPElement.cpp
+++ b/parsers/http/src/HTTPElement.cpp
@@ -130,6 +130,7 @@ auto zpt::init(zpt::http::basic_request& _req) -> void {
     strftime(_buffer_date, 80, "%a, %d %b %Y %X %Z", &_ptm);
 
     _req.performative(zpt::Get);
+    _req.header("Accept", "*/*");
     _req.header("User-Agent", "zapata");
     _req.header("Date", std::string(_buffer_date));
     _req.header("Content-Type", "application/json");


### PR DESCRIPTION
- In SSL socket, the correct hostname must be added to the context
- Resolving the hostname in case it's passed on to socket creation