### PR TITLE
HTTP request content-type related issues

### DIFF
--- a/network/http/src/retrieve.cpp
+++ b/network/http/src/retrieve.cpp
@@ -8,8 +8,6 @@
 #include <zapata/net/socket/socket_stream.h>
 
 auto zpt::http::retrieve(zpt::message _to_send) -> zpt::message {
-    _to_send->header("Content-Type", "application/json");
-
     auto _scheme = _to_send->uri()("scheme")->string();
     auto _use_ssl = (_scheme == "https");
     auto _domain = _to_send->uri()("domain")->string();

--- a/network/upnp/src/upnp_message.cpp
+++ b/network/upnp/src/upnp_message.cpp
@@ -43,7 +43,8 @@ auto zpt::upnp::basic_request::to_stream(std::ostream& _out) const -> zpt::basic
 
     std::string _body{ "" };
     if (this->__underlying("body")->ok()) {
-        if (this->__underlying("headers")("Content-Type") == "application/json") {
+        if (this->__underlying("headers")("Content-Type")->stringify().find("application/json") !=
+            std::string::npos) {
             _body.assign(static_cast<std::string>(this->__underlying("body")));
         }
         else { _body.assign(this->__underlying("body")->string()); }
@@ -92,7 +93,8 @@ auto zpt::upnp::basic_reply::to_stream(std::ostream& _out) const -> zpt::basic_m
     }
 
     if (this->__underlying("body")->ok()) {
-        if (this->__underlying("headers")("Content-Type") == "application/json") {
+        if (this->__underlying("headers")("Content-Type")->stringify().find("application/json") !=
+            std::string::npos) {
             auto _body = this->__underlying("body")->stringify();
             _out << "Content-Length: " << _body.length() << CRLF << CRLF << _body;
         }

--- a/parsers/http/src/HTTPRep.cpp
+++ b/parsers/http/src/HTTPRep.cpp
@@ -70,7 +70,8 @@ auto zpt::http::basic_reply::to_stream(std::ostream& _out) const -> zpt::basic_m
     }
 
     if (this->__underlying("body")->ok()) {
-        if (this->__underlying("headers")("Content-Type") == "application/json") {
+        if (this->__underlying("headers")("Content-Type")->stringify().find("application/json") !=
+            std::string::npos) {
             auto _body = this->__underlying("body")->stringify();
             _out << "Content-Length: " << _body.length() << CRLF << CRLF << _body;
         }

--- a/parsers/http/src/HTTPReq.cpp
+++ b/parsers/http/src/HTTPReq.cpp
@@ -69,7 +69,8 @@ auto zpt::http::basic_request::to_stream(std::ostream& _out) const -> zpt::basic
 
     std::string _body{ "" };
     if (this->__underlying("body")->ok()) {
-        if (this->__underlying("headers")("Content-Type") == "application/json") {
+        if (this->__underlying("headers")("Content-Type")->stringify().find("application/json") !=
+            std::string::npos) {
             _body.assign(static_cast<std::string>(this->__underlying("body")));
         }
         else { _body.assign(this->__underlying("body")->string()); }


### PR DESCRIPTION
- In `zpt::http::retrieve`, `application/json` was being forced (debugging and
  testing leftovers).
- When processing a message (either request or reply), the check for the type of
  content was being done by comparing the full header value with
  `application/json` instead of finding it as a sub-string.