### PR TITLE
DB connector sorting and pagination

### DIFF
--- a/generators/rest/include/zapata/generator/rest/rest.h
+++ b/generators/rest/include/zapata/generator/rest/rest.h
@@ -129,7 +129,9 @@ class unit {
     auto generate_redirect(zpt::ast::basic_file::ptr _cpp_file, zpt::json _def, zpt::json _path)
       -> void;
 
-    auto add_db_configuration(zpt::ast::basic_code_block::ptr _block, zpt::json _def) -> void;
+    auto add_db_configuration(zpt::ast::basic_code_block::ptr _block,
+                              zpt::json _def,
+                              bool _with_collection = true) -> void;
     auto add_parameters_and_validation(zpt::ast::basic_code_block::ptr _block,
                                        zpt::json _def,
                                        zpt::json _path) -> void;

--- a/generators/rest/src/rest.cpp
+++ b/generators/rest/src/rest.cpp
@@ -449,7 +449,9 @@ auto zpt::gen::rest::unit::generate_document(zpt::json _def, zpt::json _path)
                 zpt::ast::PUBLIC, "remove_element", "zpt::events::state");
             auto _retrieve_element =
               zpt::make_function<zpt::ast::cpp_function>("retrieve_element", "zpt::json");
-            _retrieve_element->add<zpt::ast::cpp_variable>("_id", "std::string const&")
+            _retrieve_element //
+              ->add<zpt::ast::cpp_variable>("_session", "zpt::storage::session&")
+              .add<zpt::ast::cpp_variable>("_id", "std::string const&")
               .add<zpt::ast::cpp_variable>("_params = zpt::undefined", "zpt::json");
             _class->add(_retrieve_element, zpt::ast::PRIVATE);
         }
@@ -911,13 +913,18 @@ auto zpt::gen::rest::unit::generate_retrieve_element(zpt::ast::basic_file::ptr _
 
     auto _method = zpt::make_function<zpt::ast::cpp_function>(
       std::format("{}retrieve_element", _class_method_prefix), "zpt::json");
-    _method->add<zpt::ast::cpp_variable>("_id", "std::string const&")
+    _method //
+      ->add<zpt::ast::cpp_variable>("_session", "zpt::storage::session&")
+      .add<zpt::ast::cpp_variable>("_id", "std::string const&")
       .add<zpt::ast::cpp_variable>("_params", "zpt::json");
     auto _method_body = zpt::make_code_block<zpt::ast::cpp_code_block>();
-    this->add_db_configuration(_method_body, _def);
 
     _method_body //
       ->add<zpt::ast::cpp_instruction>(
+        std::format("auto _collection = _session->database(\"{}\")->collection(\"{}\")",
+                    this->__schema("info")("database")->string(),
+                    _def("*")("requestBody")("dbCollection")->string()))
+      .add<zpt::ast::cpp_instruction>(
         std::format("zpt::json _fields = {}", this->get_visible_fields(_def)))
       .add<zpt::ast::cpp_instruction>("_fields << \"_id\"")
       .add<zpt::ast::cpp_instruction>(this->remove_hidden_fields(_def))
@@ -960,7 +967,7 @@ auto zpt::gen::rest::unit::generate_update_element(zpt::ast::basic_file::ptr _cp
     auto _if_block = zpt::make_code_block<zpt::ast::cpp_code_block>("if (_result != 0)");
     _if_block //
       ->add<zpt::ast::cpp_instruction>(
-        "this //\n->to_send()->status(202).body() = this->retrieve_element(_id)");
+        "this //\n->to_send()->status(202).body() = this->retrieve_element(_session, _id)");
     _method_try_body->add(_if_block);
     auto _else_block = zpt::make_code_block<zpt::ast::cpp_code_block>("else");
     _else_block->add<zpt::ast::cpp_instruction>("this->to_send()->status(404)");
@@ -989,13 +996,15 @@ auto zpt::gen::rest::unit::generate_get_element(zpt::ast::basic_file::ptr _cpp_f
     auto _method = zpt::make_function<zpt::ast::cpp_function>(
       std::format("{}get_element", _class_method_prefix), "zpt::events::state");
     auto _method_body = zpt::make_code_block<zpt::ast::cpp_code_block>();
+    this->add_db_configuration(_method_body, _def, false);
     _method_body //
       ->add<zpt::ast::cpp_instruction>("auto _params = this->received()->parameters()");
     this->add_parameters_and_validation(_method_body, _def, _path);
 
     auto _method_try_body = zpt::make_code_block<zpt::ast::cpp_code_block>("try");
     _method_try_body //
-      ->add<zpt::ast::cpp_instruction>("auto _result = this->retrieve_element(_id, _params)");
+      ->add<zpt::ast::cpp_instruction>(
+        "auto _result = this->retrieve_element(_session, _id, _params)");
     auto _if_block = zpt::make_code_block<zpt::ast::cpp_code_block>("if (_result->ok())");
     _if_block //
       ->add<zpt::ast::cpp_instruction>("this //\n->to_send()->status(200).body() = _result");
@@ -1147,16 +1156,20 @@ auto zpt::gen::rest::unit::generate_redirect(zpt::ast::basic_file::ptr _cpp_file
 }
 
 auto zpt::gen::rest::unit::add_db_configuration(zpt::ast::basic_code_block::ptr _block,
-                                                zpt::json _def) -> void {
+                                                zpt::json _def,
+                                                bool _with_collection) -> void {
     _block //
       ->add<zpt::ast::cpp_instruction>("auto _config = zpt::GLOBAL_CONFIG()")
       .add<zpt::ast::cpp_instruction>(std::format(
         "auto _session = zpt::make_connection<zpt::storage::{}::connection>(_config)->session()",
-        this->__schema("info")("dbDriver")->string()))
-      .add<zpt::ast::cpp_instruction>(
-        std::format("auto _collection = _session->database(\"{}\")->collection(\"{}\")",
-                    this->__schema("info")("database")->string(),
-                    _def("*")("requestBody")("dbCollection")->string()));
+        this->__schema("info")("dbDriver")->string()));
+    if (_with_collection) {
+        _block-> //
+          add<zpt::ast::cpp_instruction>(
+            std::format("auto _collection = _session->database(\"{}\")->collection(\"{}\")",
+                        this->__schema("info")("database")->string(),
+                        _def("*")("requestBody")("dbCollection")->string()));
+    }
 }
 
 auto zpt::gen::rest::unit::add_parameters_and_validation(zpt::ast::basic_code_block::ptr _block,
@@ -1331,7 +1344,7 @@ auto zpt::gen::rest::unit::generate_sql_schemata_mysql(zpt::json _def)
          << std::endl
          << "use " << this->__schema("info")("database")->string() << ";" << std::endl
          << "drop table if exists " << _collection << ";" << std::endl
-         << "create table " << _collection << " (\n_id varchar(36) not null," << std::endl;
+         << "create table " << _collection << " (\n_id varchar(22) not null," << std::endl;
 
     for (auto const& [_, __, _object] : _def("allOf")) {
         for (auto const& [_, _name, _field] : _object("properties")) {
@@ -1344,7 +1357,7 @@ auto zpt::gen::rest::unit::generate_sql_schemata_mysql(zpt::json _def)
                            ? std::format("varchar({})", _field("maximum")->integer())
                            : "text");
             }
-            else if (_field("type")->string() == "uuid") { _type = "varchar(36)"; }
+            else if (_field("type")->string() == "uuid") { _type = "varchar(22)"; }
             else if (_field("type")->string() == "object") { _type = "json"; }
             else if (_field("type")->string() == "array") { _type = "json"; }
 

--- a/generators/rest/src/rest.cpp
+++ b/generators/rest/src/rest.cpp
@@ -848,7 +848,7 @@ auto zpt::gen::rest::unit::generate_list_elements(zpt::ast::basic_file::ptr _cpp
     auto _if_block = zpt::make_code_block<zpt::ast::cpp_code_block>("if (_result->size() != 0)");
     _if_block //
       ->add<zpt::ast::cpp_instruction>("this //\n->to_send()->status(200).body() = { \"items\", "
-                                       "_result, \"size\", _result->size() }")
+                                       "_result, \"size\", _collection->count() }")
       .add<zpt::ast::cpp_instruction>("zpt::storage::reply_find(this->to_send()->body(), _params)");
     _method_try_body->add(_if_block);
     auto _else_block = zpt::make_code_block<zpt::ast::cpp_code_block>("else");

--- a/generators/rest/src/rest.cpp
+++ b/generators/rest/src/rest.cpp
@@ -847,8 +847,9 @@ auto zpt::gen::rest::unit::generate_list_elements(zpt::ast::basic_file::ptr _cpp
         "auto _result = _find //\n->fields(_fields)->execute()->fetch()");
     auto _if_block = zpt::make_code_block<zpt::ast::cpp_code_block>("if (_result->size() != 0)");
     _if_block //
-      ->add<zpt::ast::cpp_instruction>("this //\n->to_send()->status(200).body() = { \"items\", "
-                                       "_result, \"size\", _collection->count() }")
+      ->add<zpt::ast::cpp_instruction>(
+        "this //\n->to_send()->status(200).body() = { \"items\", "
+        "_result, \"size\", _collection->count(zpt::storage::extract_find(_params)) }")
       .add<zpt::ast::cpp_instruction>("zpt::storage::reply_find(this->to_send()->body(), _params)");
     _method_try_body->add(_if_block);
     auto _else_block = zpt::make_code_block<zpt::ast::cpp_code_block>("else");

--- a/io/stream/src/streams.cpp
+++ b/io/stream/src/streams.cpp
@@ -22,6 +22,7 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <malloc.h>
 #include <systemd/sd-daemon.h>
 #include <zapata/streams/streams.h>
 
@@ -181,6 +182,7 @@ auto zpt::polling::delegate(zpt::stream _stream) -> zpt::polling& {
         if (d(this->shared_from_this(), _stream)) { return (*this); }
     }
     this->unmute(_stream);
+    malloc_trim(0);
     return (*this);
 }
 

--- a/storage/connector/include/zapata/connector/connector.h
+++ b/storage/connector/include/zapata/connector/connector.h
@@ -250,7 +250,7 @@ class collection {
         /** @brief Creates a find action with search criteria. */
         virtual auto find(zpt::json _search) const -> zpt::storage::action = 0;
         /** @brief Returns the total count of documents. */
-        virtual auto count() -> size_t = 0;
+        virtual auto count(zpt::json _search = zpt::undefined) -> size_t = 0;
     };
 
     /** @brief Default constructor (null collection). */

--- a/storage/connector/src/connector.cpp
+++ b/storage/connector/src/connector.cpp
@@ -395,8 +395,15 @@ auto zpt::storage::filter_find(zpt::storage::collection& _collection, zpt::json 
         if (_to_find("order_by")->ok()) {
             auto _sort = zpt::split(_to_find("order_by")->string(), ",");
             for (auto [_, __, _expr] : _sort) {
+                auto _name = _expr->string();
+                bool _asc{ true };
+                if (_name[0] == '-') {
+                    _asc = false;
+                    _name = _name.substr(1);
+                }
+                else if (_name[0] == '+') { _name = _name.substr(1); }
                 _find //
-                  ->sort(_expr);
+                  ->sort(_name, _asc);
             }
         }
         return _find;
@@ -430,8 +437,15 @@ auto zpt::storage::filter_remove(zpt::storage::collection& _collection, zpt::jso
         if (_to_remove("order_by")->ok()) {
             auto _sort = zpt::split(_to_remove("order_by")->string(), ",");
             for (auto [_, __, _expr] : _sort) {
+                auto _name = _expr->string();
+                bool _asc{ true };
+                if (_name[0] == '-') {
+                    _asc = false;
+                    _name = _name.substr(1);
+                }
+                else if (_name[0] == '+') { _name = _name.substr(1); }
                 _remove //
-                  ->sort(_expr);
+                  ->sort(_name, _asc);
             }
         }
         return _remove;

--- a/storage/mysqlx/include/zapata/mysqlx/connector.h
+++ b/storage/mysqlx/include/zapata/mysqlx/connector.h
@@ -175,7 +175,7 @@ class collection : public zpt::storage::collection::type {
     /** @brief Creates a SELECT action with the given search criteria. */
     virtual auto find(zpt::json _search) const -> zpt::storage::action override;
     /** @brief Returns the total number of rows in the table. */
-    virtual auto count() -> size_t override;
+    virtual auto count(zpt::json _search = zpt::undefined) -> size_t override;
 
     /** @brief Returns the table name. */
     auto table() const -> std::string const&;

--- a/storage/mysqlx/src/connector.cpp
+++ b/storage/mysqlx/src/connector.cpp
@@ -107,6 +107,8 @@ auto zpt::storage::mysqlx::session::is_open() const -> bool { return this->__mys
 auto zpt::storage::mysqlx::session::commit() -> zpt::storage::session::type* {
     expect(0 == mysql_query(this->__mysql.get(), "COMMIT"),
            std::format("Commit failed: {}", mysql_error(this->__mysql.get())));
+    expect(0 == mysql_query(this->__mysql.get(), "START TRANSACTION"),
+           std::format("Transaction failed to start: {}", mysql_error(this->__mysql.get())));
     return this;
 }
 

--- a/storage/mysqlx/src/connector.cpp
+++ b/storage/mysqlx/src/connector.cpp
@@ -188,9 +188,27 @@ auto zpt::storage::mysqlx::collection::find(zpt::json _search) const -> zpt::sto
 
 auto zpt::storage::mysqlx::collection::count() -> size_t {
     auto _statement = std::format("select count(1) from `{}`", this->__table);
-    expect(0 == mysql_query(this->__mysql.get(), _statement.data()),
+
+    mysql_stmt_ptr _to_exec{ mysql_stmt_init(this->__mysql.get()),
+                             zpt::storage::mysqlx::mysql_stmt_end{} };
+    expect(0 == mysql_stmt_prepare(_to_exec.get(), _statement.data(), _statement.length()),
+           std::format(
+             "failed to prepare statement '{}': {}", _statement, mysql_error(this->__mysql.get())));
+    expect(0 == mysql_stmt_execute(_to_exec.get()),
            std::format(
              "failed to execute statement '{}': {}", _statement, mysql_error(this->__mysql.get())));
+
+    result_set_metadata _metadata{ _to_exec.get() };
+
+    mysql_stmt_bind_result(_to_exec.get(), _metadata.__bind.get());
+    mysql_stmt_store_result(_to_exec.get());
+
+    int _status = mysql_stmt_fetch(_to_exec.get());
+    if (_status == MYSQL_NO_DATA) { return 0; }
+
+    auto _result = zpt::storage::mysqlx::to_json(_to_exec.get(), _metadata);
+    zlog(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> " << _result, zpt::debug);
+
     return 0;
 }
 

--- a/storage/mysqlx/src/connector.cpp
+++ b/storage/mysqlx/src/connector.cpp
@@ -209,7 +209,7 @@ auto zpt::storage::mysqlx::collection::count() -> size_t {
     auto _result = zpt::storage::mysqlx::to_json(_to_exec.get(), _metadata);
     zlog(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> " << _result, zpt::debug);
 
-    return 0;
+    return _result("count(1)")->ok() ? _result("count(1)")->integer() : 0;
 }
 
 auto zpt::storage::mysqlx::collection::table() const -> std::string const& { return this->__table; }

--- a/storage/mysqlx/src/connector.cpp
+++ b/storage/mysqlx/src/connector.cpp
@@ -688,11 +688,11 @@ auto zpt::storage::mysqlx::action_find::execute() -> zpt::storage::result {
         for (auto const& [_, _field, _direction] : this->__suffix["order by"]) {
             if (!_first) { _oss << ", "; }
             _first = false;
-            _oss << _field << " " << _direction;
+            _oss << _field << " " << _direction->string();
         }
     }
 
-    _oss << std::flush;
+    _oss << ";" << std::flush;
     auto _sql = _oss.str();
 
     this->__statement.reset(mysql_stmt_init(this->__mysql.get()),

--- a/storage/mysqlx/src/connector.cpp
+++ b/storage/mysqlx/src/connector.cpp
@@ -186,8 +186,12 @@ auto zpt::storage::mysqlx::collection::find(zpt::json _search) const -> zpt::sto
     return zpt::make_action<zpt::storage::mysqlx::action_find>(*this, _search);
 }
 
-auto zpt::storage::mysqlx::collection::count() -> size_t {
-    auto _statement = std::format("select count(1) from `{}`", this->__table);
+auto zpt::storage::mysqlx::collection::count(zpt::json _search) -> size_t {
+    auto _statement = std::format("select count(1) from `{}`{}",
+                                  this->__table,
+                                  (_search->ok() && _search->string().length() != 0
+                                     ? std::format(" where {}", _search->string())
+                                     : ""));
 
     mysql_stmt_ptr _to_exec{ mysql_stmt_init(this->__mysql.get()),
                              zpt::storage::mysqlx::mysql_stmt_end{} };
@@ -207,8 +211,6 @@ auto zpt::storage::mysqlx::collection::count() -> size_t {
     if (_status == MYSQL_NO_DATA) { return 0; }
 
     auto _result = zpt::storage::mysqlx::to_json(_to_exec.get(), _metadata);
-    zlog(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> " << _result, zpt::debug);
-
     return _result("count(1)")->ok() ? _result("count(1)")->integer() : 0;
 }
 

--- a/storage/mysqlx/src/connector.cpp
+++ b/storage/mysqlx/src/connector.cpp
@@ -680,17 +680,17 @@ auto zpt::storage::mysqlx::action_find::execute() -> zpt::storage::result {
     _oss << std::vformat(zpt::storage::mysqlx::to_query(this->__fields, this->__underlying),
                          std::make_format_args(this->__table));
 
-    if (this->__suffix["limit"]->ok()) { _oss << " limit " << this->__suffix["limit"]; }
-    if (this->__suffix["offset"]->ok()) { _oss << " offset " << this->__suffix["offset"]; }
     if (this->__suffix["order by"]->ok()) {
         _oss << " order by ";
         bool _first{ true };
         for (auto const& [_, _field, _direction] : this->__suffix["order by"]) {
             if (!_first) { _oss << ", "; }
             _first = false;
-            _oss << _field << " " << _direction->string();
+            _oss << "`" << _field << "` " << _direction->string();
         }
     }
+    if (this->__suffix["limit"]->ok()) { _oss << " limit " << this->__suffix["limit"]; }
+    if (this->__suffix["offset"]->ok()) { _oss << " offset " << this->__suffix["offset"]; }
 
     _oss << ";" << std::flush;
     auto _sql = _oss.str();

--- a/storage/mysqlx/src/translate.cpp
+++ b/storage/mysqlx/src/translate.cpp
@@ -341,9 +341,10 @@ auto zpt::storage::mysqlx::to_query(zpt::json _fields, zpt::json _filter) -> std
     else { _oss << "*"; }
     _oss << " from `{}`";
 
-    if (_filter->ok()) { _oss << " where " << _filter->string(); }
+    if (_filter->ok() && _filter->string().length() != 0) {
+        _oss << " where " << _filter->string();
+    }
 
-    _oss << ";" << std::flush;
     return _oss.str();
 }
 

--- a/storage/sqlite/include/zapata/sqlite/connector.h
+++ b/storage/sqlite/include/zapata/sqlite/connector.h
@@ -169,7 +169,7 @@ class collection : public zpt::storage::collection::type {
     /** @brief Returns a SELECT action builder for rows matching the given search criteria. */
     virtual auto find(zpt::json _search) const -> zpt::storage::action override;
     /** @brief Returns the total number of rows in the SQLite table. */
-    virtual auto count() -> size_t override;
+    virtual auto count(zpt::json _search = zpt::undefined) -> size_t override;
 
   private:
     sqlite3_ptr __underlying{ nullptr };

--- a/storage/sqlite/src/connector.cpp
+++ b/storage/sqlite/src/connector.cpp
@@ -300,9 +300,13 @@ auto zpt::storage::sqlite::collection::find(zpt::json _search) const -> zpt::sto
     return zpt::make_action<zpt::storage::sqlite::action_find>(*this, _search);
 }
 
-auto zpt::storage::sqlite::collection::count() -> size_t {
+auto zpt::storage::sqlite::collection::count(zpt::json _search) -> size_t {
     std::ostringstream _oss;
     _oss << "select count(*) from \"" << this->__collection_name << "\"" << std::flush;
+    if (_search->ok() && _search->string().length() != 0) {
+        _oss << " where " << _search->string();
+    }
+
     std::string _to_execute{ _oss.str() };
     sqlite3_stmt* _stmt{ nullptr };
     sqlite_expect(

--- a/storage/sqlite/src/connector.cpp
+++ b/storage/sqlite/src/connector.cpp
@@ -255,10 +255,9 @@ auto zpt::storage::sqlite::database::sql(std::string const& _to_execute)
     sqlite_expect(
       sqlite3_prepare_v2(
         this->__underlying.get(), _to_execute.data(), _to_execute.length(), &_stmt, nullptr),
-      "unable to prepare statement for commit: " << sqlite3_errmsg(this->__underlying.get()));
-    sqlite_expect(
-      sqlite3_step(_stmt),
-      "unable to execute commit statement: " << sqlite3_errmsg(this->__underlying.get()));
+      "unable to prepare statement: " << sqlite3_errmsg(this->__underlying.get()));
+    sqlite_expect(sqlite3_step(_stmt),
+                  "unable to execute statement: " << sqlite3_errmsg(this->__underlying.get()));
     sqlite_expect(sqlite3_finalize(_stmt),
                   "unable to cleanup statement: " << sqlite3_errmsg(this->__underlying.get()));
     return this;
@@ -309,10 +308,9 @@ auto zpt::storage::sqlite::collection::count() -> size_t {
     sqlite_expect(
       sqlite3_prepare_v2(
         this->__underlying.get(), _to_execute.data(), _to_execute.length(), &_stmt, nullptr),
-      "unable to prepare statement for commit: " << sqlite3_errmsg(this->__underlying.get()));
-    sqlite_expect(
-      sqlite3_step(_stmt),
-      "unable to execute commit statement: " << sqlite3_errmsg(this->__underlying.get()));
+      "unable to prepare statement: " << sqlite3_errmsg(this->__underlying.get()));
+    sqlite_expect(sqlite3_step(_stmt),
+                  "unable to execute statement: " << sqlite3_errmsg(this->__underlying.get()));
     zpt::json _count = zpt::storage::sqlite::from_db_doc(_stmt);
     sqlite_expect(sqlite3_finalize(_stmt),
                   "unable to cleanup statement: " << sqlite3_errmsg(this->__underlying.get()));
@@ -340,7 +338,7 @@ auto zpt::storage::sqlite::action::prepare(std::string const& _statement) -> voi
     sqlite_expect(
       sqlite3_prepare_v2(
         this->__underlying.get(), _statement.data(), _statement.length(), &_stmt, nullptr),
-      "unable to prepare statement for commit: " << sqlite3_errmsg(this->__underlying.get()));
+      "unable to prepare statement: " << sqlite3_errmsg(this->__underlying.get()));
     this->__prepared.push_back(
       sqlite3_stmt_ptr{ _stmt, zpt::storage::sqlite::finalize_statement{} });
 }


### PR DESCRIPTION
- Added `-/+` semantics to `order_by` in order to provide a way to state sorting
  direction.
- Added ability to count the total number of records for a query, independently
  of the pagination setup.