### PR TITLE
Binding to a specific address

### DIFF
--- a/io/socket/include/zapata/net/socket/socket_stream.h
+++ b/io/socket/include/zapata/net/socket/socket_stream.h
@@ -76,6 +76,7 @@ auto ssl_error_print(SSL* _ssl, int _ret) -> std::string;
 auto ssl_error_print(unsigned long _error = 0) -> std::string;
 /** @brief Tests if an IP address is a multicast address. */
 auto is_multicast_address(std::string const& _ip) -> bool;
+auto bind_to_address(zpt::sockaddrin_t& _to_bind, std::string const& _address) -> bool;
 
 /**
  * @brief Stream buffer backed by a network socket.
@@ -317,7 +318,7 @@ class basic_serversocketstream {
     /** @brief Default constructor (unbound). */
     basic_serversocketstream();
     /** @brief Binds to a TCP port. */
-    basic_serversocketstream(std::uint16_t _port);
+    basic_serversocketstream(std::string const& _address, std::uint16_t _port);
     /** @brief Binds to a Unix domain socket path. */
     basic_serversocketstream(std::string const& _path);
     virtual ~basic_serversocketstream();
@@ -333,7 +334,7 @@ class basic_serversocketstream {
      * @param _port Port number to bind to.
      * @return True on success.
      */
-    auto bind(std::uint16_t _port) -> bool;
+    auto bind(std::string const& _address, std::uint16_t _port) -> bool;
     /**
      * @brief Binds to a Unix domain socket path and starts listening.
      * @param _path Filesystem path for the socket.
@@ -364,7 +365,7 @@ class serversocketstream {
   public:
     serversocketstream();
     /** @brief Binds to a TCP port. */
-    serversocketstream(std::uint16_t _port);
+    serversocketstream(std::string const& _address, std::uint16_t _port);
     /** @brief Binds to a Unix domain socket path. */
     serversocketstream(std::string const& _path);
     serversocketstream(const serversocketstream& _rhs);
@@ -392,7 +393,7 @@ class wserversocketstream {
   public:
     wserversocketstream();
     /** @brief Binds to a TCP port. */
-    wserversocketstream(std::uint16_t _port);
+    wserversocketstream(std::string const& _address, std::uint16_t _port);
     /** @brief Binds to a Unix domain socket path. */
     wserversocketstream(std::string const& _path);
     wserversocketstream(const zpt::wserversocketstream& _rhs);
@@ -982,19 +983,7 @@ auto zpt::basic_socketstream<Char>::open(std::string const& _path) -> bool {
 template<typename Char>
 auto zpt::basic_socketstream<Char>::open_ip() -> bool {
     auto& _in_address = reinterpret_cast<zpt::sockaddrin_t&>(this->__buf.address());
-    in_addr_t _addr = inet_addr(this->__buf.host().data());
-    if (_addr == INADDR_NONE) {
-        addrinfo _hints{};
-        _hints.ai_family = AF_INET;
-        _hints.ai_socktype = SOCK_STREAM;
-        addrinfo* _results = nullptr;
-        if (getaddrinfo(this->__buf.host().data(), nullptr, &_hints, &_results) == 0 &&
-            _results != nullptr) {
-            _addr = reinterpret_cast<sockaddr_in*>(_results->ai_addr)->sin_addr.s_addr;
-            freeaddrinfo(_results);
-        }
-    }
-    _in_address.sin_addr.s_addr = _addr;
+    zpt::bind_to_address(_in_address, this->__buf.host());
 
     auto _sd = ::socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
     if (::connect(_sd, &this->__buf.address(), sizeof this->__buf.address()) < 0) {
@@ -1046,19 +1035,7 @@ auto zpt::basic_socketstream<Char>::open_udp() -> bool {
 template<typename Char>
 auto zpt::basic_socketstream<Char>::open_ssl() -> bool {
     auto& _in_address = reinterpret_cast<zpt::sockaddrin_t&>(this->__buf.address());
-    in_addr_t _addr = inet_addr(this->__buf.host().data());
-    if (_addr == INADDR_NONE) {
-        addrinfo _hints{};
-        _hints.ai_family = AF_INET;
-        _hints.ai_socktype = SOCK_STREAM;
-        addrinfo* _results = nullptr;
-        if (getaddrinfo(this->__buf.host().data(), nullptr, &_hints, &_results) == 0 &&
-            _results != nullptr) {
-            _addr = reinterpret_cast<sockaddr_in*>(_results->ai_addr)->sin_addr.s_addr;
-            freeaddrinfo(_results);
-        }
-    }
-    _in_address.sin_addr.s_addr = _addr;
+    zpt::bind_to_address(_in_address, this->__buf.host());
 
     auto _sd = ::socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
     if (::connect(_sd,
@@ -1118,9 +1095,10 @@ zpt::basic_serversocketstream<Char>::basic_serversocketstream()
   : __sockfd{ 0 } {}
 
 template<typename Char>
-zpt::basic_serversocketstream<Char>::basic_serversocketstream(std::uint16_t _port)
+zpt::basic_serversocketstream<Char>::basic_serversocketstream(std::string const& _address,
+                                                              std::uint16_t _port)
   : __sockfd{ 0 } {
-    this->bind(_port);
+    this->bind(_address, _port);
 }
 
 template<typename Char>
@@ -1155,7 +1133,8 @@ auto zpt::basic_serversocketstream<Char>::ready() -> bool {
 }
 
 template<typename Char>
-auto zpt::basic_serversocketstream<Char>::bind(std::uint16_t _port) -> bool {
+auto zpt::basic_serversocketstream<Char>::bind(std::string const& _address, std::uint16_t _port)
+  -> bool {
     this->__port = _port;
     this->__protocol = IPPROTO_TCP;
     this->__sockfd = ::socket(AF_INET, SOCK_STREAM, 0);
@@ -1173,8 +1152,14 @@ auto zpt::basic_serversocketstream<Char>::bind(std::uint16_t _port) -> bool {
     struct sockaddr_in _serv_addr;
     bzero((char*)&_serv_addr, sizeof _serv_addr);
     _serv_addr.sin_family = AF_INET;
-    _serv_addr.sin_addr.s_addr = INADDR_ANY;
     _serv_addr.sin_port = htons(_port);
+    if (!zpt::bind_to_address(_serv_addr, _address)) {
+        ::shutdown(this->__sockfd, SHUT_RDWR);
+        ::close(this->__sockfd);
+        this->__sockfd = 0;
+        return false;
+    }
+
     if (::bind(this->__sockfd, reinterpret_cast<zpt::sockaddr_t*>(&_serv_addr), sizeof _serv_addr) <
         0) {
         ::shutdown(this->__sockfd, SHUT_RDWR);

--- a/io/socket/src/socket_stream.cpp
+++ b/io/socket/src/socket_stream.cpp
@@ -60,11 +60,29 @@ auto zpt::is_multicast_address(std::string const& _ip) -> bool {
     return _ip_range >= 224 && _ip_range <= 239;
 }
 
+auto zpt::bind_to_address(zpt::sockaddrin_t& _to_bind, std::string const& _address) -> bool {
+    in_addr_t _addr = inet_addr(_address.c_str());
+    if (_addr == INADDR_NONE) {
+        addrinfo _hints{};
+        _hints.ai_family = AF_INET;
+        _hints.ai_socktype = SOCK_STREAM;
+        addrinfo* _results = nullptr;
+        if (getaddrinfo(_address.c_str(), nullptr, &_hints, &_results) == 0 &&
+            _results != nullptr) {
+            _addr = reinterpret_cast<sockaddr_in*>(_results->ai_addr)->sin_addr.s_addr;
+            freeaddrinfo(_results);
+        }
+        else { return false; }
+    }
+    _to_bind.sin_addr.s_addr = _addr;
+    return true;
+}
+
 zpt::serversocketstream::serversocketstream()
   : __underlying{ zpt::allocate_shared<zpt::basic_serversocketstream<char>>() } {}
 
-zpt::serversocketstream::serversocketstream(std::uint16_t _port)
-  : __underlying{ zpt::allocate_shared<zpt::basic_serversocketstream<char>>(_port) } {}
+zpt::serversocketstream::serversocketstream(std::string const& _address, std::uint16_t _port)
+  : __underlying{ zpt::allocate_shared<zpt::basic_serversocketstream<char>>(_address, _port) } {}
 
 zpt::serversocketstream::serversocketstream(std::string const& _path)
   : __underlying{ zpt::allocate_shared<zpt::basic_serversocketstream<char>>(_path) } {}
@@ -96,8 +114,8 @@ auto zpt::serversocketstream::operator*() -> zpt::basic_serversocketstream<char>
 zpt::wserversocketstream::wserversocketstream()
   : __underlying{ zpt::allocate_shared<zpt::basic_serversocketstream<wchar_t>>() } {}
 
-zpt::wserversocketstream::wserversocketstream(std::uint16_t _port)
-  : __underlying{ zpt::allocate_shared<zpt::basic_serversocketstream<wchar_t>>(_port) } {}
+zpt::wserversocketstream::wserversocketstream(std::string const& _address, std::uint16_t _port)
+  : __underlying{ zpt::allocate_shared<zpt::basic_serversocketstream<wchar_t>>(_address, _port) } {}
 
 zpt::wserversocketstream::wserversocketstream(std::string const& _path)
   : __underlying{ zpt::allocate_shared<zpt::basic_serversocketstream<wchar_t>>(_path) } {}

--- a/io/socket/src/test_server.cpp
+++ b/io/socket/src/test_server.cpp
@@ -9,7 +9,7 @@ auto main(int argc, char* argv[]) -> int {
             _iss.str(std::string{ argv[2] });
             std::uint16_t _port{ 0 };
             _iss >> _port;
-            _ssock = zpt::allocate_unique<zpt::serversocketstream>(_port);
+            _ssock = zpt::allocate_unique<zpt::serversocketstream>("0.0.0.0", _port);
         }
         else if (_type == "-u") {
             std::string _path{ argv[2] };

--- a/network/http/include/zapata/net/transport/http.h
+++ b/network/http/include/zapata/net/transport/http.h
@@ -81,5 +81,6 @@ class http : public zpt::basic_transport {
  * @brief Returns the global HTTP server socket.
  * @param _port Port to bind (0 for configured default).
  */
-auto HTTP_SERVER_SOCKET(std::uint16_t _port = 0) -> zpt::serversocketstream&;
+auto HTTP_SERVER_SOCKET(std::string const& _address = "0.0.0.0", std::uint16_t _port = 0)
+  -> zpt::serversocketstream&;
 } // namespace zpt

--- a/network/http/src/http.cpp
+++ b/network/http/src/http.cpp
@@ -72,7 +72,8 @@ auto zpt::net::transport::http::process_incoming_reply(zpt::stream _stream) cons
     return _reply;
 }
 
-auto zpt::HTTP_SERVER_SOCKET(std::uint16_t _port) -> zpt::serversocketstream& {
-    static zpt::serversocketstream _global{ _port };
+auto zpt::HTTP_SERVER_SOCKET(std::string const& _address, std::uint16_t _port)
+  -> zpt::serversocketstream& {
+    static zpt::serversocketstream _global{ _address, _port };
     return _global;
 }

--- a/network/http/src/plugin.cpp
+++ b/network/http/src/plugin.cpp
@@ -35,6 +35,7 @@ extern "C" auto _zpt_load_(zpt::plugin& _plugin) -> void {
 
     if (_config("port")->ok()) {
         auto& _server_sock = zpt::HTTP_SERVER_SOCKET(
+          _config("bind")->string(),
           static_cast<std::uint16_t>(static_cast<unsigned int>(_config("port"))));
 
         _plugin.add_thread([&]() -> void {

--- a/network/tcp/include/zapata/net/transport/tcp.h
+++ b/network/tcp/include/zapata/net/transport/tcp.h
@@ -68,5 +68,6 @@ class tcp : public zpt::basic_transport {
  * @brief Returns the global TCP server socket.
  * @param _port Port to bind (0 for configured default).
  */
-auto TCP_SERVER_SOCKET(std::uint16_t _port = 0) -> zpt::serversocketstream&;
+auto TCP_SERVER_SOCKET(std::string const& _address = "0.0.0.0", std::uint16_t _port = 0)
+  -> zpt::serversocketstream&;
 } // namespace zpt

--- a/network/tcp/src/plugin.cpp
+++ b/network/tcp/src/plugin.cpp
@@ -34,6 +34,7 @@ extern "C" auto _zpt_load_(zpt::plugin& _plugin) -> void {
 
     if (_config("port")->ok()) {
         auto& _server_sock = zpt::TCP_SERVER_SOCKET(
+          _config("bind")->string(),
           static_cast<std::uint16_t>(static_cast<unsigned int>(_config("port"))));
 
         _plugin.add_thread([=]() mutable -> void {

--- a/network/tcp/src/tcp.cpp
+++ b/network/tcp/src/tcp.cpp
@@ -42,8 +42,7 @@ auto zpt::net::transport::tcp::make_reply(bool _with_allocator) const -> zpt::me
 }
 
 auto zpt::net::transport::tcp::make_reply(zpt::message _request) const -> zpt::message {
-    auto _to_return =
-      zpt::make_message<zpt::json_message>(_request, true);
+    auto _to_return = zpt::make_message<zpt::json_message>(_request, true);
     return _to_return;
 }
 
@@ -61,7 +60,8 @@ auto zpt::net::transport::tcp::process_incoming_reply(zpt::stream _stream) const
     return _message;
 }
 
-auto zpt::TCP_SERVER_SOCKET(std::uint16_t _port) -> zpt::serversocketstream& {
-    static zpt::serversocketstream _global{ _port };
+auto zpt::TCP_SERVER_SOCKET(std::string const& _address, std::uint16_t _port)
+  -> zpt::serversocketstream& {
+    static zpt::serversocketstream _global{ _address, _port };
     return _global;
 }

--- a/network/tcp/src/test.cpp
+++ b/network/tcp/src/test.cpp
@@ -35,7 +35,7 @@ auto main(int argc, char* argv[]) -> int {
 
         if (_type == "server") {
 
-            zpt::serversocketstream _ssock{ _port };
+            zpt::serversocketstream _ssock{ "0.0.0.0", _port };
             do {
                 auto _stream = _ssock->accept();
                 _stream->transport("tcp");

--- a/network/transport/src/test.cpp
+++ b/network/transport/src/test.cpp
@@ -54,7 +54,7 @@ auto main(int argc, char* argv[]) -> int {
         _iss >> _port;
 
         zpt::transport _transport{ new some_protocol{} };
-        zpt::serversocketstream _ssock{ _port };
+        zpt::serversocketstream _ssock{ "0.0.0.0", _port };
         do {
             auto _stream = _ssock->accept();
             auto _t1 = std::chrono::high_resolution_clock::now();

--- a/network/transport/src/transport.cpp
+++ b/network/transport/src/transport.cpp
@@ -122,14 +122,6 @@ auto zpt::network::layer::add(std::string const& _scheme, zpt::transport _transp
         expect(_port.length() != 0,
                std::format("Transport {} must have defined listening port or path", _scheme));
 
-        if (_host.find("${") == 0) {
-            _host.assign(_host.substr(2, _host.length() - 3));
-            if (_host == "any") { _host.assign(zpt::net::getip()); }
-            else { _host.assign(zpt::net::getip(_host)); }
-
-            this->__configuration[_scheme]["bind"] = _host;
-        }
-
         this->__configuration["transport"]["addresses"]
           << std::format("{}://{}{}", _scheme, _host, _port);
     }

--- a/network/websocket/include/zapata/net/transport/websocket.h
+++ b/network/websocket/include/zapata/net/transport/websocket.h
@@ -76,5 +76,6 @@ class websocket : public zpt::basic_transport {
  * @brief Returns the global WebSocket server socket.
  * @param _port Port to bind (0 for configured default).
  */
-auto WEBSOCKET_SERVER_SOCKET(std::uint16_t _port = 0) -> zpt::serversocketstream&;
+auto WEBSOCKET_SERVER_SOCKET(std::string const& _address = "0.0.0.0", std::uint16_t _port = 0)
+  -> zpt::serversocketstream&;
 } // namespace zpt

--- a/network/websocket/src/plugin.cpp
+++ b/network/websocket/src/plugin.cpp
@@ -33,6 +33,7 @@ extern "C" auto _zpt_load_(zpt::plugin& _plugin) -> void {
 
     if (_config("port")->ok()) {
         auto& _server_sock = zpt::WEBSOCKET_SERVER_SOCKET(
+          _config("bind")->string(),
           static_cast<std::uint16_t>(static_cast<unsigned int>(_config("port"))));
 
         _plugin.add_thread([=]() mutable -> void {

--- a/network/websocket/src/websocket.cpp
+++ b/network/websocket/src/websocket.cpp
@@ -123,8 +123,7 @@ auto zpt::net::transport::websocket::make_reply(bool _with_allocator) const -> z
 }
 
 auto zpt::net::transport::websocket::make_reply(zpt::message _request) const -> zpt::message {
-    auto _to_return =
-      zpt::make_message<zpt::json_message>(_request, true);
+    auto _to_return = zpt::make_message<zpt::json_message>(_request, true);
     return _to_return;
 }
 
@@ -144,7 +143,8 @@ auto zpt::net::transport::websocket::process_incoming_reply(zpt::stream _stream)
     return _message;
 }
 
-auto zpt::WEBSOCKET_SERVER_SOCKET(std::uint16_t _port) -> zpt::serversocketstream& {
-    static zpt::serversocketstream _global{ _port };
+auto zpt::WEBSOCKET_SERVER_SOCKET(std::string const& _address, std::uint16_t _port)
+  -> zpt::serversocketstream& {
+    static zpt::serversocketstream _global{ _address, _port };
     return _global;
 }

--- a/parsers/http/src/test.cpp
+++ b/parsers/http/src/test.cpp
@@ -31,7 +31,7 @@ auto main(int argc, char* argv[]) -> int {
         std::uint16_t _port{ 0 };
         _iss >> _port;
 
-        zpt::serversocketstream _ssock{ _port };
+        zpt::serversocketstream _ssock{ "0.0.0.0", _port };
         do {
             auto _csock = _ssock->accept();
             auto _t1 = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
- Added IP as a required parameter for `zpt::serversocket_stream`, to bind to a
  specific address.
- Remove the usage of `${any}` for the `bind` parameter in protocol
  configuration, use `0.0.0.0` for any address.