### PR TITLE
Muting and unmuting of streams properly serialized

### DIFF
--- a/io/stream/src/streams.cpp
+++ b/io/stream/src/streams.cpp
@@ -164,11 +164,11 @@ auto zpt::polling::insert(zpt::stream _stream) -> zpt::polling& {
 auto zpt::polling::erase(zpt::stream _stream) -> zpt::polling& {
     auto _fd = static_cast<int>(*_stream);
     epoll_ctl(this->__epoll_fd, EPOLL_CTL_DEL, _fd, nullptr);
-    _stream->shutdown();
     {
         std::unique_lock _sentry{ this->__poll_lock };
         this->__polled_streams.erase(this->__polled_streams.find(_fd));
     }
+    _stream->shutdown();
     return (*this);
 }
 

--- a/io/stream/src/streams.cpp
+++ b/io/stream/src/streams.cpp
@@ -156,7 +156,7 @@ auto zpt::polling::insert(zpt::stream _stream) -> zpt::polling& {
     _stream->__muted = false;
     {
         std::unique_lock _sentry{ this->__poll_lock };
-        this->__polled_streams.emplace(static_cast<int>(*_stream), _stream);
+        this->__polled_streams[static_cast<int>(*_stream)] = _stream;
     }
     return (*this);
 }

--- a/io/stream/src/streams.cpp
+++ b/io/stream/src/streams.cpp
@@ -151,13 +151,13 @@ auto zpt::polling::insert(zpt::stream _stream) -> zpt::polling& {
     zpt::epoll_event_t _new_event;
     _new_event.events = EPOLLIN | EPOLLPRI | EPOLLERR | EPOLLHUP | EPOLLRDHUP;
     _new_event.data.ptr = _stream.get();
-    auto _fd = static_cast<int>(*_stream);
-    epoll_ctl(this->__epoll_fd, EPOLL_CTL_ADD, _fd, &_new_event);
-    _stream->__muted = false;
     {
         std::unique_lock _sentry{ this->__poll_lock };
         this->__polled_streams[static_cast<int>(*_stream)] = _stream;
     }
+    _stream->__muted = false;
+    auto _fd = static_cast<int>(*_stream);
+    epoll_ctl(this->__epoll_fd, EPOLL_CTL_ADD, _fd, &_new_event);
     return (*this);
 }
 

--- a/io/stream/src/streams.cpp
+++ b/io/stream/src/streams.cpp
@@ -136,14 +136,14 @@ auto zpt::polling::unmute(zpt::stream _stream) -> zpt::polling& {
         return (*this);
     }
 
+    _stream->__muted = false;
+
     zpt::epoll_event_t _new_event;
     _new_event.events = EPOLLIN | EPOLLPRI | EPOLLERR | EPOLLHUP | EPOLLRDHUP;
     _new_event.data.ptr = _stream.get();
 
     auto _fd = static_cast<int>(*_stream);
     epoll_ctl(this->__epoll_fd, EPOLL_CTL_ADD, _fd, &_new_event);
-
-    _stream->__muted = false;
     return (*this);
 }
 


### PR DESCRIPTION
- Rearranged the order by which streams are unmuted, removed from the polling
  map and removed from the `epoll` socket.
