### PR TITLE
Cast from JSON to string should return empty string if JSON is Null/Undefined

### DIFF
--- a/parsers/json/src/JSONElement.cpp
+++ b/parsers/json/src/JSONElement.cpp
@@ -642,6 +642,10 @@ zpt::JSONElementT::operator std::string() {
             _out.assign(zpt::timestamp(this->date()));
             break;
         }
+        case zpt::JSUndefined:
+        case zpt::JSNil: {
+            break;
+        }
         default: {
             this->stringify(_out);
         }


### PR DESCRIPTION
- The string representation of `undefined` must be an empty string and not the string _"undefined"_.