### PR TITLE
Changing configuration with command line parameters

### DIFF
--- a/engines/rest/examples/consumer.conf
+++ b/engines/rest/examples/consumer.conf
@@ -3,7 +3,7 @@
         "id": "3ca77f4d-4e6c-44ff-b151-3d86c0a9f495",
         "name": "example-rest-consumer"
     },
-    "log": { "level": 7, "format": 1 },
+    "log": { "level": 6, "format": 1 },
     "load": [
         { "name": "builtin:http" },
         { "name": "builtin:tcp" },

--- a/engines/rest/examples/provider.conf
+++ b/engines/rest/examples/provider.conf
@@ -3,7 +3,7 @@
         "id": "a4a444e4-a6e0-11f0-99fa-ff740730cd76",
         "name": "example-rest-provider"
     },
-    "log": { "level": 9, "format": 1 },
+    "log": { "level": 6, "format": 1 },
     "load": [
         { "name": "builtin:http" },
         { "name": "builtin:tcp" },

--- a/engines/startup/src/configuration.cpp
+++ b/engines/startup/src/configuration.cpp
@@ -41,4 +41,14 @@ auto zpt::startup::configuration::load(zpt::json _parameters, zpt::json& _output
     }
     zpt::conf::dirs(_output);
     zpt::conf::env(_output);
+
+    for (auto [_, __, _value] : _parameters("--")) {
+        auto _pair = _value->string();
+        auto _idx = _pair.find(":");
+        if (_idx == std::string::npos) { continue; }
+
+        auto _path = _pair.substr(0, _idx);
+        auto _to_set = zpt::json::parse_json_str(_pair.substr(_idx + 1));
+        _output->set_path(_path, _to_set);
+    }
 }

--- a/network/websocket/examples/provider.conf
+++ b/network/websocket/examples/provider.conf
@@ -3,7 +3,7 @@
         "id": "a4a444e4-a6e0-11f0-99fa-ff740730cd76",
         "name": "example-ws-provider"
     },
-    "log": { "level": 9, "format": 1 },
+    "log": { "level": 6, "format": 1 },
     "load": [
         { "name": "builtin:http" },
         { "name": "builtin:ws" },


### PR DESCRIPTION
- All non-positional parameters are assumed in the form `json_path:value` and used to change the configuration object (for instance, `http.port:9090` sets the port for HTTP transport).