### PR TITLE
Remove `std::tuple` from JSON iteration due to GCC16 bug

### DIFF
--- a/parsers/json/include/zapata/json/JSONClass.h
+++ b/parsers/json/include/zapata/json/JSONClass.h
@@ -112,14 +112,15 @@ enum JSONType {
 auto to_string(zpt::JSONType _type) -> std::string;
 
 // Forward declarations
-class JSONElementT; ///< Internal JSON element implementation
-class JSONObj;      ///< JSON object wrapper
-class JSONArr;      ///< JSON array wrapper
-class JSONLambda;   ///< Lambda function implementation
-class JSONRegex;    ///< Regular expression implementation
-class JSONIterator; ///< Iterator for JSON containers
-class lambda;       ///< Lambda function wrapper
-class json;         ///< Main JSON value class
+class JSONElementT;  ///< Internal JSON element implementation
+class JSONObj;       ///< JSON object wrapper
+class JSONArr;       ///< JSON array wrapper
+class JSONLambda;    ///< Lambda function implementation
+class JSONRegex;     ///< Regular expression implementation
+class JSONIterator;  ///< Iterator for JSON containers
+class lambda;        ///< Lambda function wrapper
+class json;          ///< Main JSON value class
+struct json_element; ///< JSON iterator target type
 
 /** @brief Alias for JSONRegex. */
 using regex = JSONRegex;
@@ -252,7 +253,7 @@ class json {
     /** @brief Map type used internally for objects. */
     using map = std::map<std::string, zpt::json>;
     /** @brief Element tuple: (index, key, value). */
-    using element = std::tuple<size_t, std::string, zpt::json>;
+    using element = json_element;
     /** @brief Iterator type. */
     using iterator = zpt::JSONIterator;
     /** @brief Const iterator type. */
@@ -333,7 +334,7 @@ class json {
     /** @brief Move assignment. */
     auto operator=(zpt::json&& _rhs) -> zpt::json&;
     /** @brief Assignment from iterator element tuple. */
-    auto operator=(std::tuple<size_t, std::string, zpt::json> _rhs) -> zpt::json&;
+    auto operator=(element _rhs) -> zpt::json&;
     /** @brief Assignment from initializer list. */
     auto operator=(std::initializer_list<zpt::json> _list) -> zpt::json&;
     /** @brief Assignment from any compatible type. */
@@ -356,9 +357,9 @@ class json {
     /** @name Comparison Operators */
     ///@{
     /** @brief Equality with iterator element tuple. */
-    auto operator==(std::tuple<size_t, std::string, zpt::json> _rhs) const -> bool;
+    auto operator==(element _rhs) const -> bool;
     /** @brief Inequality with iterator element tuple. */
-    auto operator!=(std::tuple<size_t, std::string, zpt::json> _rhs) const -> bool;
+    auto operator!=(element _rhs) const -> bool;
     /** @brief Equality with nullptr (checks if null/undefined). */
     auto operator==(std::nullptr_t _rhs) const -> bool;
     /** @brief Inequality with nullptr. */
@@ -648,7 +649,7 @@ class json {
   private:
     std::shared_ptr<zpt::JSONElementT> __underlying{ nullptr };
 
-    json(std::tuple<size_t, std::string, zpt::json> _rhs);
+    json(element _rhs);
     auto strict_union(zpt::json _rhs) -> void;
     auto strict_intersection(zpt::json _rhs) -> void;
 
@@ -656,7 +657,15 @@ class json {
                          zpt::json::traverse_callback _callback,
                          std::string _path) -> void;
 };
+
+struct json_element {
+    size_t __index;
+    std::string __name;
+    zpt::json __value;
+};
 } // namespace zpt
+
+static_assert(std::is_move_constructible<zpt::json>::value);
 
 /**
  * @brief std::formatter specialization for zpt::json.
@@ -1832,7 +1841,7 @@ class JSONElementT {
      * @param _pos Position index.
      * @return Tuple for iteration; key is empty for arrays.
      */
-    virtual auto element(size_t _pos) -> std::tuple<size_t, std::string, zpt::json>;
+    virtual auto element(size_t _pos) -> zpt::json::element;
 
   private:
     JSONElementT* __parent{ nullptr };

--- a/parsers/json/src/JSONElement.cpp
+++ b/parsers/json/src/JSONElement.cpp
@@ -1648,11 +1648,10 @@ auto zpt::JSONElementT::prettify() const -> std::string {
     return _out;
 }
 
-auto zpt::JSONElementT::element(size_t _pos) -> std::tuple<size_t, std::string, zpt::json> {
+auto zpt::JSONElementT::element(size_t _pos) -> zpt::json::element {
     switch (this->__underlying.index()) {
-        case zpt::JSObject:
-            return std::make_tuple(_pos, this->object()->key_for(_pos), this->object()[_pos]);
-        case zpt::JSArray: return std::make_tuple(_pos, std::to_string(_pos), this->array()[_pos]);
+        case zpt::JSObject: return { _pos, this->object()->key_for(_pos), this->object()[_pos] };
+        case zpt::JSArray: return { _pos, std::to_string(_pos), this->array()[_pos] };
         case zpt::JSString:
         case zpt::JSInteger:
         case zpt::JSDouble:
@@ -1663,5 +1662,5 @@ auto zpt::JSONElementT::element(size_t _pos) -> std::tuple<size_t, std::string, 
         case zpt::JSLambda:
         case zpt::JSRegex: break;
     }
-    return std::make_tuple(0, "", zpt::json{ *this });
+    return { 0, "", zpt::json{ *this } };
 }

--- a/parsers/json/src/JSONPtr.cpp
+++ b/parsers/json/src/JSONPtr.cpp
@@ -69,7 +69,7 @@ zpt::json::json(zpt::allocator<zpt::JSONElementT>::shared_pointer _target)
 
 zpt::json::json(std::initializer_list<zpt::json> _init) { (*this) = _init; }
 
-zpt::json::json(std::tuple<size_t, std::string, zpt::json> _rhs) { (*this) = _rhs; }
+zpt::json::json(element _rhs) { (*this) = _rhs; }
 
 zpt::json::~json() {}
 
@@ -92,8 +92,8 @@ auto zpt::json::operator=(zpt::json&& _rhs) -> zpt::json& {
     return (*this);
 }
 
-auto zpt::json::operator=(std::tuple<size_t, std::string, zpt::json> _rhs) -> zpt::json& {
-    this->__underlying = std::get<2>(_rhs).__underlying;
+auto zpt::json::operator=(element _rhs) -> zpt::json& {
+    this->__underlying = _rhs.__value.__underlying;
     return (*this);
 }
 
@@ -142,13 +142,9 @@ auto zpt::json::operator->() const -> zpt::JSONElementT const* { return this->__
 
 auto zpt::json::operator*() const -> zpt::JSONElementT const& { return *this->__underlying.get(); }
 
-auto zpt::json::operator==(std::tuple<size_t, std::string, zpt::json> _rhs) const -> bool {
-    return (*this) == std::get<2>(_rhs);
-}
+auto zpt::json::operator==(element _rhs) const -> bool { return (*this) == _rhs.__value; }
 
-auto zpt::json::operator!=(std::tuple<size_t, std::string, zpt::json> _rhs) const -> bool {
-    return (*this) != std::get<2>(_rhs);
-}
+auto zpt::json::operator!=(element _rhs) const -> bool { return (*this) != _rhs.__value; }
 
 auto zpt::json::operator==(std::nullptr_t) const -> bool {
     return this->__underlying->type() == zpt::JSNil;
@@ -1110,7 +1106,7 @@ auto zpt::json::flatten(zpt::json _document) -> zpt::json {
 auto zpt::json::find(zpt::json::iterator _begin, zpt::json::iterator _end, zpt::json _to_find)
   -> zpt::json::iterator {
     for (zpt::json::iterator _to_return = _begin; _to_return != _end; ++_to_return) {
-        if (std::get<2>(*_to_return) == _to_find) { return _to_return; }
+        if ((*_to_return).__value == _to_find) { return _to_return; }
     }
     return _end;
 }
@@ -1197,17 +1193,16 @@ auto zpt::JSONIterator::operator++() -> JSONIterator& {
 auto zpt::JSONIterator::operator*() -> reference {
     switch (this->__target->type()) {
         case zpt::JSObject: {
-            return std::make_tuple(
-              this->__index, this->__iterator->first, this->__iterator->second);
+            return { this->__index, this->__iterator->first, this->__iterator->second };
         }
         case zpt::JSArray: {
-            return std::make_tuple(this->__index, "", (**this->__target->array())[this->__index]);
+            return { this->__index, "", (**this->__target->array())[this->__index] };
         }
         default: {
             break;
         }
     }
-    return std::make_tuple(this->__index, "", this->__target);
+    return { this->__index, "", this->__target };
 }
 
 auto zpt::JSONIterator::operator++(int) -> JSONIterator {
@@ -1219,17 +1214,16 @@ auto zpt::JSONIterator::operator++(int) -> JSONIterator {
 auto zpt::JSONIterator::operator->() -> pointer {
     switch (this->__target->type()) {
         case zpt::JSObject: {
-            return std::make_tuple(
-              this->__index, this->__iterator->first, this->__iterator->second);
+            return { this->__index, this->__iterator->first, this->__iterator->second };
         }
         case zpt::JSArray: {
-            return std::make_tuple(this->__index, "", (**this->__target->array())[this->__index]);
+            return { this->__index, "", (**this->__target->array())[this->__index] };
         }
         default: {
             break;
         }
     }
-    return std::make_tuple(this->__index, "", this->__target);
+    return { this->__index, "", this->__target };
 }
 
 auto zpt::JSONIterator::operator==(JSONIterator const& _rhs) const -> bool {


### PR DESCRIPTION
    - Due to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71301 a circularity in
      std::tuple usage is being reported without existing in fact, changed structure
      used in JSON iterator to a `struct`.
