### PR TITLE
Accessing by reference JSON iterator elements

### DIFF
--- a/bridges/lua/src/lua.cpp
+++ b/bridges/lua/src/lua.cpp
@@ -229,7 +229,7 @@ auto zpt::lua::bridge::to_object(zpt::json _to_convert, object_type _return)
         case zpt::JSObject: {
             lua_newtable(_return);
             int _index = lua_gettop(_return);
-            for (auto [_, _key, _value] : _to_convert) {
+            for (auto&& [_, _key, _value] : _to_convert) {
                 lua_pushstring(_return, _key.data());
                 this->to_object(_value, _return);
                 lua_settable(_return, _index);
@@ -239,7 +239,7 @@ auto zpt::lua::bridge::to_object(zpt::json _to_convert, object_type _return)
         case zpt::JSArray: {
             lua_newtable(_return);
             int _index = lua_gettop(_return);
-            for (auto [_idx, _, _value] : _to_convert) {
+            for (auto&& [_idx, _, _value] : _to_convert) {
                 lua_pushinteger(_return, _idx + 1);
                 this->to_object(_value, _return);
                 lua_settable(_return, _index);
@@ -329,15 +329,15 @@ auto zpt::lua::bridge::execute() -> zpt::lua::bridge::object_type {
 
 auto zpt::lua::bridge::to_args(zpt::json _args) -> zpt::lua::bridge& {
     expect(_args->is_array(), "Lua: `to_args` parameter `_args` must be an array");
-    for (auto [_, __, _arg] : _args) { this->to_object(_arg, this->__underlying); }
+    for (auto&& [_, __, _arg] : _args) { this->to_object(_arg, this->__underlying); }
     return (*this);
 }
 
 auto zpt::lua::bridge::initialize() -> zpt::lua::bridge& {
-    for (auto [_file, _conf] : this->__external_to_load) {
+    for (auto&& [_file, _conf] : this->__external_to_load) {
         this->setup_module(_conf, _file, false);
     }
-    for (auto [_, _pair] : this->__builtin_to_load) {
+    for (auto&& [_, _pair] : this->__builtin_to_load) {
         auto [_callback, _conf] = _pair;
         this->setup_module(_conf, _callback, false);
     }

--- a/bridges/lua/src/plugin.cpp
+++ b/bridges/lua/src/plugin.cpp
@@ -28,7 +28,7 @@ extern "C" auto _zpt_load_(zpt::plugin& _plugin) -> void {
     auto& _bridge = zpt::LUA_BRIDGE();
     _bridge.set_options(_plugin.config());
     if (_bridge.options()("modules")->is_array()) {
-        for (auto [_, __, _module] : _bridge.options()("modules")) {
+        for (auto&& [_, __, _module] : _bridge.options()("modules")) {
             _bridge.add_module(_module("file")->string(), _module);
         }
     }

--- a/bridges/prolog/src/plugin.cpp
+++ b/bridges/prolog/src/plugin.cpp
@@ -28,7 +28,7 @@ extern "C" auto _zpt_load_(zpt::plugin&) -> void {
     // auto& _bridge = zpt::PROLOG_BRIDGE();
     // _bridge.set_options(_plugin.config());
     // if (_bridge.options()("modules")->is_array()) {
-    //     for (auto [_, __, _module] : _bridge.options()("modules")) {
+    //     for (auto&& [_, __, _module] : _bridge.options()("modules")) {
     //         _bridge.add_module(_module("file")->string(), _module);
     //     }
     // }

--- a/common/catalog/examples/catalog.cpp
+++ b/common/catalog/examples/catalog.cpp
@@ -33,11 +33,11 @@ auto main(int, char**) -> int {
       4,
       { "host", "localhost", "port", 8080, "callback", zpt::json::lambda("factory", 2) });
 
-    for (auto [_, _key, _record] : _catalog.search("/users/n@zgul.me/info")) {
+    for (auto&& [_, _key, _record] : _catalog.search("/users/n@zgul.me/info")) {
         zpt::json::parse_json_str(_record("metadata")->string())("callback")
           ->lambda()({ zpt::array, _key, _record }, zpt::context{ nullptr });
     }
-    for (auto [_, _key, _record] : _catalog.search("/users/n@zgul.me")) {
+    for (auto&& [_, _key, _record] : _catalog.search("/users/n@zgul.me")) {
         zpt::json::parse_json_str(_record("metadata")->string())("callback")
           ->lambda()({ zpt::array, _key, _record }, zpt::context{ nullptr });
     }

--- a/common/catalog/include/zapata/catalog/catalog.h
+++ b/common/catalog/include/zapata/catalog/catalog.h
@@ -220,7 +220,7 @@ auto zpt::catalog<K, M>::resolve(K const& _pattern) const -> zpt::json const {
 
     for (auto const& [_idx, __, _part] : _parts) {
         if (_idx == _parts->size() - 1) {
-            for (auto [_, __, _prefix] : _prefixes) {
+            for (auto&& [_, __, _prefix] : _prefixes) {
                 _result += this
                              ->__catalog                            //
                              ->find(std::format(EXACT_RESOLVE_STMT, //
@@ -240,7 +240,7 @@ auto zpt::catalog<K, M>::resolve(K const& _pattern) const -> zpt::json const {
         else {
             zpt::json _matching = zpt::json::array();
 
-            for (auto [_, __, _prefix] : _prefixes) {
+            for (auto&& [_, __, _prefix] : _prefixes) {
                 auto _count = this
                                 ->__catalog                      //
                                 ->find(std::format(RESOLVE_STMT, //
@@ -299,7 +299,7 @@ auto zpt::catalog<K, M>::search(K const& _pattern, std::string const& _provider)
 
     for (auto const& [_idx, __, _part] : _parts) {
         if (_idx == _parts->size() - 1) {
-            for (auto [_, __, _prefix] : _prefixes) {
+            for (auto&& [_, __, _prefix] : _prefixes) {
                 _result += this
                              ->__catalog                        //
                              ->find(std::vformat(_exact_search, //
@@ -318,7 +318,7 @@ auto zpt::catalog<K, M>::search(K const& _pattern, std::string const& _provider)
         else {
             zpt::json _matching = zpt::json::array();
 
-            for (auto [_, __, _prefix] : _prefixes) {
+            for (auto&& [_, __, _prefix] : _prefixes) {
                 auto _count = this
                                 ->__catalog                                                  //
                                 ->find(std::vformat(_search,                                 //
@@ -366,7 +366,7 @@ auto zpt::catalog<K, M>::list(std::string const& _provider_id) const -> zpt::jso
         ->fetch();
 
     std::istringstream _iss;
-    for (auto [_, __, _service] : _result) {
+    for (auto&& [_, __, _service] : _result) {
         if (_service("metadata")->ok()) {
             M _metadata;
             _iss.str(_service("metadata")->string());
@@ -414,7 +414,7 @@ auto zpt::catalog<K, M>::get_provider(std::string const& _id) const -> zpt::json
                         ->execute()
                         ->fetch();
 
-    for (auto [_, __, _provider] : _providers) {
+    for (auto&& [_, __, _provider] : _providers) {
         if (_provider("protocols")->ok()) {
             _provider["protocols"] = zpt::json::parse_json_str(_provider("protocols")->string());
         }

--- a/docs/api-reference/rest.md
+++ b/docs/api-reference/rest.md
@@ -340,7 +340,7 @@ resolver->register_provider({
 
 // Search for services
 auto services = resolver->search({ "path", "/api/users" });
-for (auto [_, __, svc] : services) {
+for (auto&& [_, __, svc] : services) {
     std::cout << "Found: " << svc("provider_id")->string() << std::endl;
 }
 

--- a/docs/api-reference/storage.md
+++ b/docs/api-reference/storage.md
@@ -340,7 +340,7 @@ auto results = users->find({ "active", true })
     ->execute();
 
 auto docs = results->fetch();
-for (auto [_, __, doc] : docs) {
+for (auto&& [_, __, doc] : docs) {
     std::cout << doc("name")->string() << std::endl;
 }
 

--- a/docs/guides/json.md
+++ b/docs/guides/json.md
@@ -188,7 +188,7 @@ config->del_path("database.primary.port");
 ```cpp
 zpt::json obj = { "a", 1, "b", 2, "c", 3 };
 
-for (auto [index, key, value] : obj) {
+for (auto&& [index, key, value] : obj) {
     std::cout << index << ": " << key << " = " << value << std::endl;
 }
 // Output:
@@ -197,7 +197,7 @@ for (auto [index, key, value] : obj) {
 // 2: c = 3
 
 zpt::json arr = { zpt::array, 10, 20, 30 };
-for (auto [index, key, value] : arr) {
+for (auto&& [index, key, value] : arr) {
     std::cout << index << ": " << value << std::endl;
 }
 // Output:

--- a/engines/rest/src/rest.cpp
+++ b/engines/rest/src/rest.cpp
@@ -84,7 +84,7 @@ auto zpt::rest::resolver_t::remove(zpt::performative _performative, zpt::json co
                   (_performative == zpt::Performative_end ? std::string{ "{}" }
                                                           : zpt::ontology::to_str(_performative)),
                   _path);
-    for (auto [_, __, _record] : this->__catalog.search(_to_search)) {
+    for (auto&& [_, __, _record] : this->__catalog.search(_to_search)) {
         auto _hash_code = _record("hash")->integer();
         expect(static_cast<unsigned>(_hash_code) < this->__callbacks.size(),
                "Couldn't find callback for [" << _hash_code << "](" << _path << ")");
@@ -103,7 +103,7 @@ auto zpt::rest::resolver_t::resolve(zpt::message _received,
         auto _to_search = std::format("/{}{}",
                                       zpt::ontology::to_str(_received->performative()),
                                       _received->resource()->string());
-        for (auto [_, __, _record] : this->__catalog.resolve(_to_search)) {
+        for (auto&& [_, __, _record] : this->__catalog.resolve(_to_search)) {
             auto _hash_code = _record("hash")->integer();
             expect(static_cast<unsigned>(_hash_code) < this->__callbacks.size(),
                    "Couldn't find callback for [" << _hash_code << "]("

--- a/engines/startup/src/configuration.cpp
+++ b/engines/startup/src/configuration.cpp
@@ -23,7 +23,7 @@
 #include <zapata/startup/configuration.h>
 
 auto zpt::startup::configuration::load(zpt::json _parameters, zpt::json& _output) -> void {
-    for (auto [_, __, _conf_file] : _parameters("--config")) {
+    for (auto&& [_, __, _conf_file] : _parameters("--config")) {
         try {
             zpt::conf::file(static_cast<std::string>(_conf_file), _output, _output);
         }
@@ -31,7 +31,7 @@ auto zpt::startup::configuration::load(zpt::json _parameters, zpt::json& _output
             zlog("Found " << _e, zpt::emergency);
         }
     }
-    for (auto [_, __, _conf_dir] : _parameters("--conf-dir")) {
+    for (auto&& [_, __, _conf_dir] : _parameters("--conf-dir")) {
         try {
             zpt::conf::dirs(static_cast<std::string>(_conf_dir), _output);
         }
@@ -42,7 +42,7 @@ auto zpt::startup::configuration::load(zpt::json _parameters, zpt::json& _output
     zpt::conf::dirs(_output);
     zpt::conf::env(_output);
 
-    for (auto [_, __, _value] : _parameters("--")) {
+    for (auto&& [_, __, _value] : _parameters("--")) {
         auto _pair = _value->string();
         auto _idx = _pair.find(":");
         if (_idx == std::string::npos) { continue; }

--- a/engines/startup/src/startup.cpp
+++ b/engines/startup/src/startup.cpp
@@ -139,7 +139,7 @@ auto zpt::startup::boot::load() -> zpt::startup::boot& {
     this->resolve_builtin_dependencies();
 
     auto _to_load = zpt::json::object();
-    for (auto [_idx, __, _lib] : this->__configuration("load")) {
+    for (auto&& [_idx, __, _lib] : this->__configuration("load")) {
         auto _name = _lib("name")->string();
         _to_load << _name << zpt::json::object();
     }
@@ -148,14 +148,14 @@ auto zpt::startup::boot::load() -> zpt::startup::boot& {
     while (_to_load->size() != 0 && !_no_change) {
         _no_change = true;
 
-        for (auto [_idx, __, _lib] : this->__configuration("load")) {
+        for (auto&& [_idx, __, _lib] : this->__configuration("load")) {
             auto _name = _lib("name")->string();
             if (this->__plugins.find(_name) != this->__plugins.end()) { continue; }
 
             expect(!_lib("requires")->ok() || _lib("requires")->is_array(),
                    "Configuration error: library 'requires' field must be an array");
 
-            for (auto [___, ____, _required] : _lib("requires")) {
+            for (auto&& [___, ____, _required] : _lib("requires")) {
                 if (this->__plugins.find(_required->string()) == this->__plugins.end()) {
                     _to_load[_name] << _required->string() << false;
                 }

--- a/engines/transport/include/zapata/transport/engine.h
+++ b/engines/transport/include/zapata/transport/engine.h
@@ -427,7 +427,7 @@ auto zpt::events::call<T>::operator()(zpt::events::dispatcher::ptr) -> zpt::even
         expect(_found->ok() && _found->size() != 0,
                "Couldn't find a provider of '" << _uri("path")->string());
 
-        for (auto [_, __, _service] : _found) {
+        for (auto&& [_, __, _service] : _found) {
             if ((_is_self = (_service("provider_id") == zpt::IDENTITY()("_id")))) { break; }
         }
 

--- a/network/transport/src/transport.cpp
+++ b/network/transport/src/transport.cpp
@@ -250,7 +250,7 @@ auto zpt::network::resolve_content_type(zpt::message _message) -> std::string {
         auto _mime_types = zpt::split(_accept, ",");
         double _weight{ 0 };
         std::string _highest{ "*/*" };
-        for (auto [_, __, _mime] : _mime_types) {
+        for (auto&& [_, __, _mime] : _mime_types) {
             auto _semicolon = _mime->string().find(";");
             auto _mime_name = _mime->string().substr(0, _semicolon);
             if (_semicolon != std::string::npos) {

--- a/network/upnp/src/upnp_message.cpp
+++ b/network/upnp/src/upnp_message.cpp
@@ -50,7 +50,7 @@ auto zpt::upnp::basic_request::to_stream(std::ostream& _out) const -> zpt::basic
         else { _body.assign(this->__underlying("body")->string()); }
     }
 
-    for (auto [_, _name, _value] : this->__underlying("headers")) {
+    for (auto&& [_, _name, _value] : this->__underlying("headers")) {
         _out << _name << ": " << static_cast<std::string>(_value) << CRLF;
     }
     _out << "Content-Length: " << _body.length() << CRLF;

--- a/parsers/http/src/HTTPReq.cpp
+++ b/parsers/http/src/HTTPReq.cpp
@@ -82,7 +82,7 @@ auto zpt::http::basic_request::to_stream(std::ostream& _out) const -> zpt::basic
         else { _body.assign(this->__underlying("body")->string()); }
     }
 
-    for (auto [_, _name, _value] : this->__underlying("headers")) {
+    for (auto&& [_, _name, _value] : this->__underlying("headers")) {
         _out << _name << ": " << static_cast<std::string>(_value) << CRLF;
     }
     if (!this->__underlying("headers")("Host")->ok()) {

--- a/parsers/json/include/zapata/json/JSONClass.h
+++ b/parsers/json/include/zapata/json/JSONClass.h
@@ -47,7 +47,7 @@
  * int age = obj["age"];
  *
  * // Iterate over elements
- * for (auto [idx, key, value] : obj) {
+ * for (auto&& [idx, key, value] : obj) {
  *     std::cout << key << ": " << value << std::endl;
  * }
  *
@@ -232,7 +232,7 @@ namespace zpt {
  *
  * @par Iteration
  * @code
- * for (auto [index, key, value] : obj) {
+ * for (auto&& [index, key, value] : obj) {
  *     // index: position (size_t)
  *     // key: object key or empty for arrays
  *     // value: zpt::json element

--- a/parsers/json/src/JSONPtr.cpp
+++ b/parsers/json/src/JSONPtr.cpp
@@ -291,7 +291,7 @@ auto zpt::json::operator+(zpt::json _rhs) const -> zpt::json {
     switch (this->__underlying->type()) {
         case zpt::JSObject: {
             auto _lhs = this->__underlying->clone();
-            for (auto [_idx, _key, _e] : _rhs) {
+            for (auto&& [_idx, _key, _e] : _rhs) {
                 if (_lhs[_key]->type() == zpt::JSObject || _lhs[_key]->type() == zpt::JSArray) {
                     _lhs << _key << (_lhs[_key] + _e);
                 }
@@ -302,19 +302,19 @@ auto zpt::json::operator+(zpt::json _rhs) const -> zpt::json {
         case zpt::JSArray: {
             if (_rhs->type() == zpt::JSArray) {
                 auto _lhs = this->__underlying->clone();
-                for (auto [_idx, _key, _e] : _rhs) { _lhs << _e; }
+                for (auto&& [_idx, _key, _e] : _rhs) { _lhs << _e; }
                 return _lhs;
             }
             else {
                 auto _lhs = zpt::json::array();
-                for (auto [_idx, _key, _e] : *this) { _lhs << (_e + _rhs); }
+                for (auto&& [_idx, _key, _e] : *this) { _lhs << (_e + _rhs); }
                 return _lhs;
             }
         }
         case zpt::JSString: {
             if (_rhs->type() == zpt::JSArray) {
                 auto _lhs = zpt::json::array();
-                for (auto [_idx, _key, _e] : _rhs) { _lhs << ((*this) + _e); }
+                for (auto&& [_idx, _key, _e] : _rhs) { _lhs << ((*this) + _e); }
                 return _lhs;
             }
             else {
@@ -325,7 +325,7 @@ auto zpt::json::operator+(zpt::json _rhs) const -> zpt::json {
         case zpt::JSInteger: {
             if (_rhs->type() == zpt::JSArray) {
                 auto _lhs = zpt::json::array();
-                for (auto [_idx, _key, _e] : _rhs) { _lhs << ((*this) + _e); }
+                for (auto&& [_idx, _key, _e] : _rhs) { _lhs << ((*this) + _e); }
                 return _lhs;
             }
             else { return zpt::json(this->__underlying->integer() + _rhs->number()); }
@@ -333,7 +333,7 @@ auto zpt::json::operator+(zpt::json _rhs) const -> zpt::json {
         case zpt::JSDouble: {
             if (_rhs->type() == zpt::JSArray) {
                 auto _lhs = zpt::json::array();
-                for (auto [_idx, _key, _e] : _rhs) { _lhs << ((*this) + _e); }
+                for (auto&& [_idx, _key, _e] : _rhs) { _lhs << ((*this) + _e); }
                 return _lhs;
             }
             else { return zpt::json(this->__underlying->floating() + _rhs->number()); }
@@ -341,7 +341,7 @@ auto zpt::json::operator+(zpt::json _rhs) const -> zpt::json {
         case zpt::JSBoolean: {
             if (_rhs->type() == zpt::JSArray) {
                 auto _lhs = zpt::json::array();
-                for (auto [_idx, _key, _e] : _rhs) { _lhs << ((*this) + _e); }
+                for (auto&& [_idx, _key, _e] : _rhs) { _lhs << ((*this) + _e); }
                 return _lhs;
             }
             else { return zpt::json(this->__underlying->boolean() || _rhs->number()); }
@@ -353,7 +353,7 @@ auto zpt::json::operator+(zpt::json _rhs) const -> zpt::json {
         case zpt::JSDate: {
             if (_rhs->type() == zpt::JSArray) {
                 auto _lhs = zpt::json::array();
-                for (auto [_idx, _key, _e] : _rhs) { _lhs << ((*this) + _e); }
+                for (auto&& [_idx, _key, _e] : _rhs) { _lhs << ((*this) + _e); }
                 return _lhs;
             }
             else {
@@ -379,14 +379,14 @@ auto zpt::json::operator+=(zpt::json _rhs) -> zpt::json& {
     if (_rhs->type() == zpt::JSNil) { return (*this); }
     switch (this->__underlying->type()) {
         case zpt::JSObject: {
-            for (auto [_, _key, _e] : _rhs) {
+            for (auto&& [_, _key, _e] : _rhs) {
                 if ((*this)[_key]->ok()) { (*this)[_key] += _e; }
                 else { (*this) << _key << _e; }
             }
             return (*this);
         }
         case zpt::JSArray: {
-            for (auto [_, __, _e] : _rhs) { (*this) << _e; }
+            for (auto&& [_, __, _e] : _rhs) { (*this) << _e; }
             return (*this);
         }
         case zpt::JSString: {
@@ -430,25 +430,25 @@ auto zpt::json::operator-(zpt::json _rhs) const -> zpt::json {
     switch (this->__underlying->type()) {
         case zpt::JSObject: {
             auto _lhs = this->__underlying->clone();
-            for (auto [_idx, _key, _e] : _rhs) { _lhs->object()->pop(_key); }
+            for (auto&& [_idx, _key, _e] : _rhs) { _lhs->object()->pop(_key); }
             return _lhs;
         }
         case zpt::JSArray: {
             if (_rhs->type() == zpt::JSArray) {
                 auto _lhs = zpt::json::array();
-                for (auto [_idx, _key, _e] : _rhs) { _lhs << (this[_idx] - _rhs[_idx]); }
+                for (auto&& [_idx, _key, _e] : _rhs) { _lhs << (this[_idx] - _rhs[_idx]); }
                 return _lhs;
             }
             else {
                 auto _lhs = zpt::json::array();
-                for (auto [_idx, _key, _e] : _rhs) { _lhs << (_e - _rhs); }
+                for (auto&& [_idx, _key, _e] : _rhs) { _lhs << (_e - _rhs); }
                 return _lhs;
             }
         }
         case zpt::JSString: {
             if (_rhs->type() == zpt::JSArray) {
                 auto _lhs = zpt::json::array();
-                for (auto [_idx, _key, _e] : _rhs) { _lhs << ((*this) - _e); }
+                for (auto&& [_idx, _key, _e] : _rhs) { _lhs << ((*this) - _e); }
                 return _lhs;
             }
             else {
@@ -464,7 +464,7 @@ auto zpt::json::operator-(zpt::json _rhs) const -> zpt::json {
         case zpt::JSInteger: {
             if (_rhs->type() == zpt::JSArray) {
                 auto _lhs = zpt::json::array();
-                for (auto [_idx, _key, _e] : _rhs) { _lhs << ((*this) - _e); }
+                for (auto&& [_idx, _key, _e] : _rhs) { _lhs << ((*this) - _e); }
                 return _lhs;
             }
             else { return zpt::json(this->__underlying->integer() - _rhs->number()); }
@@ -472,7 +472,7 @@ auto zpt::json::operator-(zpt::json _rhs) const -> zpt::json {
         case zpt::JSDouble: {
             if (_rhs->type() == zpt::JSArray) {
                 auto _lhs = zpt::json::array();
-                for (auto [_idx, _key, _e] : _rhs) { _lhs << ((*this) - _e); }
+                for (auto&& [_idx, _key, _e] : _rhs) { _lhs << ((*this) - _e); }
                 return _lhs;
             }
             else { return zpt::json(this->__underlying->floating() - _rhs->number()); }
@@ -480,7 +480,7 @@ auto zpt::json::operator-(zpt::json _rhs) const -> zpt::json {
         case zpt::JSBoolean: {
             if (_rhs->type() == zpt::JSArray) {
                 auto _lhs = zpt::json::array();
-                for (auto [_idx, _key, _e] : _rhs) { _lhs << ((*this) - _e); }
+                for (auto&& [_idx, _key, _e] : _rhs) { _lhs << ((*this) - _e); }
                 return _lhs;
             }
             else { return zpt::json(this->__underlying->boolean() && _rhs->number()); }
@@ -492,7 +492,7 @@ auto zpt::json::operator-(zpt::json _rhs) const -> zpt::json {
         case zpt::JSDate: {
             if (_rhs->type() == zpt::JSArray) {
                 auto _lhs = zpt::json::array();
-                for (auto [_idx, _key, _e] : _rhs) { _lhs << ((*this) - _e); }
+                for (auto&& [_idx, _key, _e] : _rhs) { _lhs << ((*this) - _e); }
                 return _lhs;
             }
             else { return zpt::json(this->__underlying->date() - _rhs->number()); }
@@ -515,13 +515,13 @@ auto zpt::json::operator-=(zpt::json _rhs) -> zpt::json& {
     if (_rhs->type() == zpt::JSNil) { return (*this); }
     switch (this->__underlying->type()) {
         case zpt::JSObject: {
-            for (auto [_, _key, __] : _rhs) { (**this).object()->pop(_key); }
+            for (auto&& [_, _key, __] : _rhs) { (**this).object()->pop(_key); }
             return (*this);
         }
         case zpt::JSArray: {
             std::vector<size_t> _to_remove;
-            for (auto [__, _, _remove] : _rhs) {
-                for (auto [_idx, ____, _value] : (*this)) {
+            for (auto&& [__, _, _remove] : _rhs) {
+                for (auto&& [_idx, ____, _value] : (*this)) {
                     if (_value == _remove) { _to_remove.push_back(_idx); }
                 }
             }
@@ -573,19 +573,19 @@ auto zpt::json::operator/(zpt::json _rhs) const -> zpt::json {
         case zpt::JSArray: {
             if (_rhs->type() == zpt::JSArray) {
                 auto _lhs = zpt::json::array();
-                for (auto [_idx, _key, _e] : _rhs) { _lhs << (this[_idx] / _rhs[_idx]); }
+                for (auto&& [_idx, _key, _e] : _rhs) { _lhs << (this[_idx] / _rhs[_idx]); }
                 return _lhs;
             }
             else {
                 auto _lhs = zpt::json::array();
-                for (auto [_idx, _key, _e] : _rhs) { _lhs << (_e / _rhs); }
+                for (auto&& [_idx, _key, _e] : _rhs) { _lhs << (_e / _rhs); }
                 return _lhs;
             }
         }
         case zpt::JSString: {
             if (_rhs->type() == zpt::JSArray) {
                 auto _lhs = zpt::json::array();
-                for (auto [_idx, _key, _e] : _rhs) { _lhs << ((*this) / _e); }
+                for (auto&& [_idx, _key, _e] : _rhs) { _lhs << ((*this) / _e); }
                 return _lhs;
             }
             else {
@@ -601,7 +601,7 @@ auto zpt::json::operator/(zpt::json _rhs) const -> zpt::json {
         case zpt::JSInteger: {
             if (_rhs->type() == zpt::JSArray) {
                 auto _lhs = zpt::json::array();
-                for (auto [_idx, _key, _e] : _rhs) { _lhs << ((*this) / _e); }
+                for (auto&& [_idx, _key, _e] : _rhs) { _lhs << ((*this) / _e); }
                 return _lhs;
             }
             else { return zpt::json(this->__underlying->integer() / _rhs->number()); }
@@ -609,7 +609,7 @@ auto zpt::json::operator/(zpt::json _rhs) const -> zpt::json {
         case zpt::JSDouble: {
             if (_rhs->type() == zpt::JSArray) {
                 auto _lhs = zpt::json::array();
-                for (auto [_idx, _key, _e] : _rhs) { _lhs << ((*this) / _e); }
+                for (auto&& [_idx, _key, _e] : _rhs) { _lhs << ((*this) / _e); }
                 return _lhs;
             }
             else { return zpt::json(this->__underlying->floating() / _rhs->number()); }
@@ -617,7 +617,7 @@ auto zpt::json::operator/(zpt::json _rhs) const -> zpt::json {
         case zpt::JSBoolean: {
             if (_rhs->type() == zpt::JSArray) {
                 auto _lhs = zpt::json::array();
-                for (auto [_idx, _key, _e] : _rhs) { _lhs << ((*this) / _e); }
+                for (auto&& [_idx, _key, _e] : _rhs) { _lhs << ((*this) / _e); }
                 return _lhs;
             }
             else { return zpt::json(this->__underlying->boolean() / _rhs->number()); }
@@ -629,7 +629,7 @@ auto zpt::json::operator/(zpt::json _rhs) const -> zpt::json {
         case zpt::JSDate: {
             if (_rhs->type() == zpt::JSArray) {
                 auto _lhs = zpt::json::array();
-                for (auto [_idx, _key, _e] : _rhs) { _lhs << ((*this) / _e); }
+                for (auto&& [_idx, _key, _e] : _rhs) { _lhs << ((*this) / _e); }
                 return _lhs;
             }
             else { return zpt::json(this->__underlying->date() / _rhs->number()); }
@@ -852,7 +852,7 @@ auto zpt::json::strict_union(zpt::json _rhs) -> void {
     switch (this->__underlying->type()) {
         case zpt::JSObject: {
             if (_rhs->type() == zpt::JSObject) {
-                for (auto [_, _key, _e] : _rhs) {
+                for (auto&& [_, _key, _e] : _rhs) {
                     if ((*this)[_key]->type() == zpt::JSObject) { (*this)[_key].strict_union(_e); }
                     else if (!(*this)[_key]->ok()) { (*this) << _key << _e; }
                 }
@@ -861,7 +861,7 @@ auto zpt::json::strict_union(zpt::json _rhs) -> void {
         }
         case zpt::JSArray: {
             if (_rhs->type() == zpt::JSArray) {
-                for (auto [_, __, _e] : _rhs) { (*this) << _e; }
+                for (auto&& [_, __, _e] : _rhs) { (*this) << _e; }
             }
             return;
         }
@@ -884,14 +884,14 @@ auto zpt::json::strict_intersection(zpt::json _rhs) -> void {
     switch (this->__underlying->type()) {
         case zpt::JSObject: {
             if (_rhs->type() == zpt::JSObject) {
-                for (auto [_, _key, _e] : _rhs) {
+                for (auto&& [_, _key, _e] : _rhs) {
                     if ((*this)(_key)->type() == zpt::JSObject ||
                         (*this)(_key)->type() == zpt::JSArray) {
                         (*this)[_key].strict_intersection(_e);
                     }
                 }
                 zpt::json _lhs = zpt::json::object();
-                for (auto [_, _key, _e] : (*this)) {
+                for (auto&& [_, _key, _e] : (*this)) {
                     if (_rhs(_key)->ok()) { _lhs << _key << _e; }
                 }
                 (*this) = _lhs;
@@ -900,14 +900,14 @@ auto zpt::json::strict_intersection(zpt::json _rhs) -> void {
         }
         case zpt::JSArray: {
             if (_rhs->type() == zpt::JSArray) {
-                for (auto [_idx, _, _e] : _rhs) {
+                for (auto&& [_idx, _, _e] : _rhs) {
                     if ((*this)(_idx)->type() == zpt::JSObject ||
                         (*this)(_idx)->type() == zpt::JSArray) {
                         (*this)[_idx].strict_intersection(_e);
                     }
                 }
                 zpt::json _lhs = zpt::json::array();
-                for (auto [_idx, _, _e] : (*this)) {
+                for (auto&& [_idx, _, _e] : (*this)) {
                     if (_e == _rhs(_idx)) { _lhs << _e; }
                 }
                 (*this) = _lhs;
@@ -1070,7 +1070,7 @@ auto zpt::json::traverse(zpt::json _document,
     switch (_document->type()) {
         case zpt::JSArray:
         case zpt::JSObject: {
-            for (auto [_idx, _name, _item] : _document) {
+            for (auto&& [_idx, _name, _item] : _document) {
                 std::string _current_path{ _document->type() == zpt::JSArray ? std::to_string(_idx)
                                                                              : _name };
                 std::string _item_path{ _path + std::string{ _path.length() == 0 ? "" : "." } +

--- a/parsers/json/src/json.cpp
+++ b/parsers/json/src/json.cpp
@@ -153,7 +153,7 @@ auto zpt::conf::evaluate_ref(zpt::json _options,
                              std::variant<std::string, size_t> const& _parent_key,
                              std::filesystem::path const& _context,
                              zpt::json _root) -> void {
-    for (auto [_idx, _key, _value] : _options) {
+    for (auto&& [_idx, _key, _value] : _options) {
         if (_options->is_object()) {
             if (_key == "$ref") {
                 auto& _ref = _value->string();

--- a/parsers/uri/src/uri.cpp
+++ b/parsers/uri/src/uri.cpp
@@ -69,7 +69,7 @@ auto zpt::uri::to_string(zpt::json const& _uri) -> std::string {
         if (_uri("params")->ok()) {
             bool _first{ true };
             _oss << "?";
-            for (auto [_, _key, _value] : _uri("params")) {
+            for (auto&& [_, _key, _value] : _uri("params")) {
                 if (!_first) { _oss << "&"; }
                 _first = false;
                 _oss << _key << "=" << (_value->ok() ? static_cast<std::string>(_value) : "");
@@ -89,10 +89,10 @@ auto zpt::uri::to_regex(zpt::json const& _in) -> zpt::json {
 
 auto zpt::uri::to_regex_object(zpt::json const& _in) -> zpt::json {
     zpt::json _to_return = zpt::json::object();
-    for (auto [_, _key, _item] : _in) {
+    for (auto&& [_, _key, _item] : _in) {
         if (_key == "path") {
             zpt::json _parts = zpt::json::array();
-            for (auto [__, ___, _part] : _item) {
+            for (auto&& [__, ___, _part] : _item) {
                 auto _casted = static_cast<std::string>(_part);
                 auto _length = _casted.length();
                 if (_casted[0] == '{' && _casted[1] == ':' && _casted[_length - 2] == ':' &&
@@ -120,7 +120,7 @@ auto zpt::uri::to_regex_object(zpt::json const& _in) -> zpt::json {
 
 auto zpt::uri::to_regex_array(zpt::json const& _in) -> zpt::json {
     zpt::json _to_return = zpt::json::array();
-    for (auto [_, __, _item] : _in) {
+    for (auto&& [_, __, _item] : _in) {
         auto _casted = static_cast<std::string>(_item);
         auto _length = _casted.length();
         if (_casted[0] == '{' && _casted[1] == ':' && _casted[_length - 2] == ':' &&
@@ -164,7 +164,7 @@ auto zpt::uri::params::to_string(zpt::json const& _uri) -> std::string {
         if (_uri("params")->ok()) {
             bool _first{ true };
             _oss << "?";
-            for (auto [_, _key, _value] : _uri("params")) {
+            for (auto&& [_, _key, _value] : _uri("params")) {
                 if (!_first) { _oss << "&"; }
                 _first = false;
                 _oss << _key << "=" << (_value->ok() ? static_cast<std::string>(_value) : "");

--- a/security/oauth2/src/oauth2.cpp
+++ b/security/oauth2/src/oauth2.cpp
@@ -88,8 +88,8 @@ auto zpt::auth::oauth2::server::authorize(std::string const& _topic,
 
     auto _roles_found{ 0ULL };
     auto _roles_granted = _identity["roles"];
-    for (auto [_, __, _role_needed] : _roles_needed) {
-        for (auto [_, __, _role_granted] : _roles_granted) {
+    for (auto&& [_, __, _role_needed] : _roles_needed) {
+        for (auto&& [_, __, _role_granted] : _roles_granted) {
             if (_role_needed == _role_granted) {
                 ++_roles_found;
                 break;

--- a/storage/connector/src/connector.cpp
+++ b/storage/connector/src/connector.cpp
@@ -36,7 +36,7 @@ auto value_output(zpt::json _value, std::ostream& _find) -> void {
 auto func_default(std::string const& _functor, zpt::json _params, std::ostream& _find) -> void {
     bool _first{ true };
     _find << "(";
-    for (auto [_, __, _value] : _params) {
+    for (auto&& [_, __, _value] : _params) {
         if (!_first) { _find << " " << _functor << " "; }
         zpt::storage::functional_to_sql(_value, _find, ::value_output);
         _first = false;
@@ -394,7 +394,7 @@ auto zpt::storage::filter_find(zpt::storage::collection& _collection, zpt::json 
         }
         if (_to_find("order_by")->ok()) {
             auto _sort = zpt::split(_to_find("order_by")->string(), ",");
-            for (auto [_, __, _expr] : _sort) {
+            for (auto&& [_, __, _expr] : _sort) {
                 auto _name = _expr->string();
                 bool _asc{ true };
                 if (_name[0] == '-') {
@@ -436,7 +436,7 @@ auto zpt::storage::filter_remove(zpt::storage::collection& _collection, zpt::jso
         }
         if (_to_remove("order_by")->ok()) {
             auto _sort = zpt::split(_to_remove("order_by")->string(), ",");
-            for (auto [_, __, _expr] : _sort) {
+            for (auto&& [_, __, _expr] : _sort) {
                 auto _name = _expr->string();
                 bool _asc{ true };
                 if (_name[0] == '-') {
@@ -458,7 +458,7 @@ auto zpt::storage::extract_find(zpt::json _to_process) -> std::string {
 
     std::ostringstream _find;
     bool _first{ true };
-    for (auto [_, _key, _value] : _to_process) {
+    for (auto&& [_, _key, _value] : _to_process) {
         if (_key == "page_size" || _key == "page_start_index" || _key == "fields" ||
             _key == "order_by") {
             continue;

--- a/storage/mysqlx/src/connector.cpp
+++ b/storage/mysqlx/src/connector.cpp
@@ -298,7 +298,7 @@ auto zpt::storage::mysqlx::action_add::bind(zpt::json) -> zpt::storage::action::
 
 auto zpt::storage::mysqlx::action_add::execute() -> zpt::storage::result {
     std::ostringstream _oss;
-    for (auto [_, __, _record] : this->__underlying) {
+    for (auto&& [_, __, _record] : this->__underlying) {
         auto _id = zpt::uuid{}.to_base64_string();
         _record << "_id" << _id;
         this->__generated_ids << _id;

--- a/storage/pgsql/src/connector.cpp
+++ b/storage/pgsql/src/connector.cpp
@@ -325,7 +325,7 @@ auto zpt::storage::pgsql::action_add::bind(zpt::json) -> zpt::storage::action::t
 
 auto zpt::storage::pgsql::action_add::execute() -> zpt::storage::result {
     std::ostringstream _oss;
-    for (auto [_, __, _record] : this->__underlying) {
+    for (auto&& [_, __, _record] : this->__underlying) {
         auto _id = zpt::uuid{}.to_base64_string();
         _record << "_id" << _id;
         this->__generated_ids << _id;

--- a/storage/sqlite/src/connector.cpp
+++ b/storage/sqlite/src/connector.cpp
@@ -444,7 +444,7 @@ auto zpt::storage::sqlite::action_add::add_insert(zpt::json _document) -> void {
     _names << "insert into \"" << this->__collection_name << "\" (" << std::flush;
     _values << " values (" << std::flush;
     bool _first{ true };
-    for (auto [_, _key, _value] : _document) {
+    for (auto&& [_, _key, _value] : _document) {
         if (!_first) {
             _names << ", ";
             _values << ", ";
@@ -510,7 +510,7 @@ auto zpt::storage::sqlite::action_modify::unset(std::string const& _attribute)
 
 auto zpt::storage::sqlite::action_modify::patch(zpt::json _document)
   -> zpt::storage::action::type* {
-    for (auto [_, _key, _member] : _document) { this->__set << _key << _member; }
+    for (auto&& [_, _key, _member] : _document) { this->__set << _key << _member; }
     return this;
 }
 
@@ -536,7 +536,7 @@ auto zpt::storage::sqlite::action_modify::bind(zpt::json _map) -> zpt::storage::
     try {
         this->add_update();
         for (auto _prepared : this->__prepared) {
-            for (auto [_, _name, _value] : _map) {
+            for (auto&& [_, _name, _value] : _map) {
                 zpt::storage::sqlite::bind(_prepared.get(), _name, _value);
             }
         }
@@ -572,7 +572,7 @@ auto zpt::storage::sqlite::action_modify::add_update() -> void {
     std::ostringstream _oss;
     _oss << "update \"" << this->__collection_name << "\" set " << std::flush;
     bool _first{ true };
-    for (auto [_, _key, _value] : this->__set) {
+    for (auto&& [_, _key, _value] : this->__set) {
         if (!_first) { _oss << ", "; }
         else { _first = false; }
         _oss << "\"" << _key << "\" = " << std::flush;
@@ -582,7 +582,7 @@ auto zpt::storage::sqlite::action_modify::add_update() -> void {
         else { _oss << _value << std::flush; }
     }
     this->__set->clear();
-    for (auto [_, _key, _value] : this->__unset) {
+    for (auto&& [_, _key, _value] : this->__unset) {
         if (!_first) { _oss << ", "; }
         else { _first = false; }
         _oss << "\"" << _key << "\" = NULL " << std::flush;
@@ -660,7 +660,7 @@ auto zpt::storage::sqlite::action_remove::bind(zpt::json _map) -> zpt::storage::
     try {
         this->add_delete();
         for (auto _prepared : this->__prepared) {
-            for (auto [_, _name, _value] : _map) {
+            for (auto&& [_, _name, _value] : _map) {
                 zpt::storage::sqlite::bind(_prepared.get(), _name, _value);
             }
         }
@@ -795,7 +795,7 @@ auto zpt::storage::sqlite::action_replace::add_replace() -> void {
     _names << "replace into \"" << this->__collection_name << "\" (" << std::flush;
     _values << " values (" << std::flush;
     bool _first{ true };
-    for (auto [_, _key, _value] : this->__set) {
+    for (auto&& [_, _key, _value] : this->__set) {
         if (!_first) {
             _names << ", ";
             _values << ", ";
@@ -893,7 +893,7 @@ auto zpt::storage::sqlite::action_find::bind(zpt::json _map) -> zpt::storage::ac
     try {
         this->add_select();
         for (auto _prepared : this->__prepared) {
-            for (auto [_, _name, _value] : _map) {
+            for (auto&& [_, _name, _value] : _map) {
                 zpt::storage::sqlite::bind(_prepared.get(), _name, _value);
             }
         }
@@ -926,7 +926,7 @@ auto zpt::storage::sqlite::action_find::add_select() -> void {
 
     if (this->__fields->size() != 0 && this->__fields->is_array()) {
         bool _first{ true };
-        for (auto [_, __, _value] : this->__fields) {
+        for (auto&& [_, __, _value] : this->__fields) {
             if (!_first) { _oss << ", "; }
             else { _first = false; }
             if (_value->is_string()) { _oss << _value; }
@@ -958,7 +958,7 @@ auto zpt::storage::sqlite::action_find::add_select() -> void {
     if (this->__sort->size() != 0 && this->__sort->is_object()) {
         _oss << " order by ";
         bool _first{ true };
-        for (auto [_, _key, _value] : this->__sort) {
+        for (auto&& [_, _key, _value] : this->__sort) {
             if (!_first) { _oss << ", "; }
             else { _first = false; }
             _oss << "\"" << _key << "\" " << _value;


### PR DESCRIPTION
- In `for` loops, use `&&` in the structure binding unpacking the JSON iterator elements, in order to avoid copying from the `struct` members.