### PR TITLE
Support for views and SQL statements in connectors and generated code 

### DIFF
--- a/bridges/lua/src/lua.cpp
+++ b/bridges/lua/src/lua.cpp
@@ -121,7 +121,7 @@ auto zpt::lua::bridge::to_json(zpt::lua::bridge::object_type _to_convert, int _i
             return lua_tonumber(_to_convert, _index);
         }
         case LUA_TBOOLEAN: {
-            return static_cast<bool>(lua_toboolean(_to_convert, _index));
+            return zpt::json::boolean(static_cast<bool>(lua_toboolean(_to_convert, _index)));
         }
         case LUA_TSTRING: {
             return lua_tostring(_to_convert, _index);

--- a/docs/api-reference/storage.md
+++ b/docs/api-reference/storage.md
@@ -67,7 +67,7 @@ Database session with transaction support.
 
 ```cpp
 virtual auto is_open() const -> bool = 0;
-virtual auto sql(std::string const& _statement) -> type* = 0;
+virtual auto sql(std::string const& _statement) -> zpt::storage::result = 0;
 virtual auto commit() -> type* = 0;
 virtual auto rollback() -> type* = 0;
 virtual auto database(std::string const& _db) const -> zpt::storage::database = 0;
@@ -82,7 +82,7 @@ Database namespace container.
 ### Inner Class: `type`
 
 ```cpp
-virtual auto sql(std::string const& _statement) -> type* = 0;
+virtual auto sql(std::string const& _statement) -> zpt::storage::result = 0;
 virtual auto collection(std::string const& _name) const -> zpt::storage::collection = 0;
 ```
 

--- a/generators/rest/src/rest.cpp
+++ b/generators/rest/src/rest.cpp
@@ -315,6 +315,11 @@ auto zpt::gen::rest::unit::generate_collection(zpt::json _def, zpt::json _path)
               ->add<zpt::ast::cpp_function>(
                 zpt::ast::PUBLIC, "process_request", "zpt::events::state");
         }
+        else if (_def("*")("requestBody")("zpt:view")->ok()) {
+            _class //
+              ->add<zpt::ast::cpp_function>(
+                zpt::ast::PUBLIC, "list_elements", "zpt::events::state");
+        }
         else {
             _class //
               ->add<zpt::ast::cpp_function>(zpt::ast::PUBLIC, "add_element", "zpt::events::state")
@@ -362,12 +367,16 @@ auto zpt::gen::rest::unit::generate_collection(zpt::json _def, zpt::json _path)
         if (_def("*")("requestBody")("zpt:redirect")->ok()) {
             this->generate_redirect(_cpp_file, _def, _path);
         }
+        else if (_def("*")("requestBody")("zpt:view")->ok()) {
+            this->generate_list_elements(_cpp_file, _def, _path);
+        }
         else {
             this->generate_add_element(_cpp_file, _def, _path);
             this->generate_list_elements(_cpp_file, _def, _path);
             this->generate_remove_elements(_cpp_file, _def, _path);
         }
 
+        std::string _allowed{ "GET, POST, DELETE" };
         auto _cpp_operator = zpt::make_function<zpt::ast::cpp_function>(
           std::format("{}operator()", _class_method_prefix), "zpt::events::state");
         _cpp_operator->add<zpt::ast::cpp_variable>("_dispatcher [[maybe_unused]]",
@@ -391,6 +400,14 @@ auto zpt::gen::rest::unit::generate_collection(zpt::json _def, zpt::json _path)
               .add(_cpp_operator_case_get)
               .add(_cpp_operator_case_delete);
         }
+        else if (_def("*")("requestBody")("zpt:view")->ok()) {
+            auto _cpp_operator_case_get =
+              zpt::make_code_block<zpt::ast::cpp_code_block>("case zpt::Get :");
+            _cpp_operator_case_get->add<zpt::ast::cpp_instruction>("return this->list_elements()");
+            _cpp_operator_switch //
+              ->add(_cpp_operator_case_get);
+            _allowed.assign("GET");
+        }
         else {
             auto _cpp_operator_case_get =
               zpt::make_code_block<zpt::ast::cpp_code_block>("case zpt::Get :");
@@ -411,8 +428,9 @@ auto zpt::gen::rest::unit::generate_collection(zpt::json _def, zpt::json _path)
         _cpp_operator_body //
           ->add(_cpp_operator_switch)
           .add<zpt::ast::cpp_instruction>(
-            "this //\n->to_send()->status(405).body() = { \"message\", \"Only GET, POST, "
-            "DELETE allowed to use with a collection\" }")
+            std::format("this //\n->to_send()->status(405).body() = {{ \"message\", \"Only {} "
+                        "allowed to use with a collection\" }}",
+                        _allowed))
           .add<zpt::ast::cpp_instruction>("return zpt::events::abort");
         _cpp_operator->add(_cpp_operator_body);
         _cpp_file->add(_cpp_operator);
@@ -459,6 +477,10 @@ auto zpt::gen::rest::unit::generate_document(zpt::json _def, zpt::json _path)
             _class //
               ->add<zpt::ast::cpp_function>(
                 zpt::ast::PUBLIC, "process_request", "zpt::events::state");
+        }
+        else if (_def("*")("requestBody")("zpt:view")->ok()) {
+            _class //
+              ->add<zpt::ast::cpp_function>(zpt::ast::PUBLIC, "get_element", "zpt::events::state");
         }
         else {
             _class //
@@ -516,12 +538,16 @@ auto zpt::gen::rest::unit::generate_document(zpt::json _def, zpt::json _path)
         if (_def("*")("requestBody")("zpt:redirect")->ok()) {
             this->generate_redirect(_cpp_file, _def, _path);
         }
+        else if (_def("*")("requestBody")("zpt:view")->ok()) {
+            this->generate_get_element(_cpp_file, _def, _path);
+        }
         else {
             this->generate_update_element(_cpp_file, _def, _path);
             this->generate_get_element(_cpp_file, _def, _path);
             this->generate_remove_element(_cpp_file, _def, _path);
         }
 
+        std::string _allowed{ "GET, PATCH, DELETE" };
         auto _cpp_operator = zpt::make_function<zpt::ast::cpp_function>(
           std::format("{}operator()", _class_method_prefix), "zpt::events::state");
         _cpp_operator->add<zpt::ast::cpp_variable>("_dispatcher [[maybe_unused]]",
@@ -545,6 +571,16 @@ auto zpt::gen::rest::unit::generate_document(zpt::json _def, zpt::json _path)
               .add(_cpp_operator_case_get)
               .add(_cpp_operator_case_delete);
         }
+        else if (_def("*")("requestBody")("zpt:view")->ok()) {
+            auto _cpp_operator_case_get =
+              zpt::make_code_block<zpt::ast::cpp_code_block>("case zpt::Get :");
+            _cpp_operator_case_get->add<zpt::ast::cpp_instruction>("return this->get_element()");
+            _cpp_operator_switch //
+              ->add(_cpp_operator_case_get);
+
+            this->generate_retrieve_element(_cpp_file, _def, _path);
+            _allowed.assign("GET");
+        }
         else {
             auto _cpp_operator_case_get =
               zpt::make_code_block<zpt::ast::cpp_code_block>("case zpt::Get :");
@@ -561,13 +597,16 @@ auto zpt::gen::rest::unit::generate_document(zpt::json _def, zpt::json _path)
               .add(_cpp_operator_case_get)
               .add(_cpp_operator_case_delete);
 
-            this->generate_retrieve_element(_cpp_file, _def, _path);
+            if (_def("*")("requestBody")("dbCollection")->is_string()) {
+                this->generate_retrieve_element(_cpp_file, _def, _path);
+            }
         }
         _cpp_operator_body //
           ->add(_cpp_operator_switch)
           .add<zpt::ast::cpp_instruction>(
-            "this //\n->to_send()->status(405).body() = { \"message\", \"Only GET, PATCH, "
-            "DELETE allowed to use with a document\" }")
+            std::format("this //\n->to_send()->status(405).body() = {{ \"message\", \"Only {} "
+                        "allowed to use with a document\" }}",
+                        _allowed))
           .add<zpt::ast::cpp_instruction>("return zpt::events::abort");
         _cpp_operator->add(_cpp_operator_body);
         _cpp_file->add(_cpp_operator);
@@ -717,6 +756,11 @@ auto zpt::gen::rest::unit::generate_store(zpt::json _def, zpt::json _path)
               ->add<zpt::ast::cpp_function>(
                 zpt::ast::PUBLIC, "process_request", "zpt::events::state");
         }
+        else if (_def("*")("requestBody")("zpt:view")->ok()) {
+            _class //
+              ->add<zpt::ast::cpp_function>(
+                zpt::ast::PUBLIC, "list_elements", "zpt::events::state");
+        }
         else {
             _class //
               ->add<zpt::ast::cpp_function>(zpt::ast::PUBLIC, "add_element", "zpt::events::state")
@@ -764,12 +808,16 @@ auto zpt::gen::rest::unit::generate_store(zpt::json _def, zpt::json _path)
         if (_def("*")("requestBody")("zpt:redirect")->ok()) {
             this->generate_redirect(_cpp_file, _def, _path);
         }
+        else if (_def("*")("requestBody")("zpt:view")->ok()) {
+            this->generate_list_elements(_cpp_file, _def, _path);
+        }
         else {
             this->generate_add_element(_cpp_file, _def, _path);
             this->generate_list_elements(_cpp_file, _def, _path);
             this->generate_remove_elements(_cpp_file, _def, _path);
         }
 
+        std::string _allowed{ "GET, POST, DELETE" };
         auto _cpp_operator = zpt::make_function<zpt::ast::cpp_function>(
           std::format("{}operator()", _class_method_prefix), "zpt::events::state");
         _cpp_operator->add<zpt::ast::cpp_variable>("_dispatcher [[maybe_unused]]",
@@ -793,6 +841,14 @@ auto zpt::gen::rest::unit::generate_store(zpt::json _def, zpt::json _path)
               .add(_cpp_operator_case_get)
               .add(_cpp_operator_case_delete);
         }
+        else if (_def("*")("requestBody")("zpt:view")->ok()) {
+            auto _cpp_operator_case_get =
+              zpt::make_code_block<zpt::ast::cpp_code_block>("case zpt::Get :");
+            _cpp_operator_case_get->add<zpt::ast::cpp_instruction>("return this->list_elements()");
+            _cpp_operator_switch //
+              ->add(_cpp_operator_case_get);
+            _allowed.assign("GET");
+        }
         else {
             auto _cpp_operator_case_get =
               zpt::make_code_block<zpt::ast::cpp_code_block>("case zpt::Get :");
@@ -812,8 +868,9 @@ auto zpt::gen::rest::unit::generate_store(zpt::json _def, zpt::json _path)
         _cpp_operator_body //
           ->add(_cpp_operator_switch)
           .add<zpt::ast::cpp_instruction>(
-            "this //\n->to_send()->status(405).body() = { \"message\", \"Only GET, PUT, "
-            "DELETE allowed to use with a store\" }")
+            std::format("this //\n->to_send()->status(405).body() = {{ \"message\", \"Only {} "
+                        "allowed to use with a store\" }}",
+                        _allowed))
           .add<zpt::ast::cpp_instruction>("return zpt::events::abort");
         _cpp_operator->add(_cpp_operator_body);
         _cpp_file->add(_cpp_operator);
@@ -901,15 +958,32 @@ auto zpt::gen::rest::unit::generate_list_elements(zpt::ast::basic_file::ptr _cpp
     this->add_parameters_and_validation(_method_body, _def, _path);
 
     auto _method_try_body = zpt::make_code_block<zpt::ast::cpp_code_block>("try");
-    _method_try_body //
-      ->add<zpt::ast::cpp_instruction>(
-        std::format("zpt::json _fields = {}", this->get_visible_fields(_def)))
-      .add<zpt::ast::cpp_instruction>("_fields << \"_id\"")
-      .add<zpt::ast::cpp_instruction>(this->remove_hidden_fields(_def));
-    if (_def("*")("requestBody")("dbCollection")->is_string()) {
-        _method_try_body //
-          ->add<zpt::ast::cpp_instruction>("auto _result = zpt::storage::filter_find(_collection, "
-                                           "_params) //\n->fields(_fields)->execute()->fetch()");
+    if (_def("*")("requestBody")("dbCollection")->is_string() ||
+        _def("*")("requestBody")("zpt:view")->ok()) {
+
+        if (_def("*")("requestBody")("dbCollection")->is_string()) {
+            _method_try_body //
+              ->add<zpt::ast::cpp_instruction>(
+                std::format("zpt::json _fields = {}", this->get_visible_fields(_def)))
+              .add<zpt::ast::cpp_instruction>("_fields << \"_id\"")
+              .add<zpt::ast::cpp_instruction>(this->remove_hidden_fields(_def));
+            _method_try_body //
+              ->add<zpt::ast::cpp_instruction>(
+                "auto _result = zpt::storage::filter_find(_collection, "
+                "_params) //\n->fields(_fields)->execute()->fetch()");
+        }
+        else if (_def("*")("requestBody")("zpt:view")->is_string()) {
+            _method_try_body //
+              ->add<zpt::ast::cpp_instruction>(
+                "auto _result = zpt::storage::filter_find(_collection, "
+                "_params) //\n->execute()->fetch()");
+        }
+        else {
+            _method_try_body //
+              ->add<zpt::ast::cpp_instruction>(
+                "auto _result = _database //\n->sql(\"STATEMTENT HERE\")->fetch()");
+        }
+
         auto _if_block =
           zpt::make_code_block<zpt::ast::cpp_code_block>("if (_result->size() != 0)");
         _if_block //
@@ -993,8 +1067,6 @@ auto zpt::gen::rest::unit::generate_remove_elements(zpt::ast::basic_file::ptr _c
 auto zpt::gen::rest::unit::generate_retrieve_element(zpt::ast::basic_file::ptr _cpp_file,
                                                      zpt::json _def,
                                                      zpt::json) -> void {
-    if (!_def("*")("requestBody")("dbCollection")->is_string()) { return; }
-
     auto _class_method_prefix =
       std::format("{}::{}::", this->__namespace, _def("*")("operationId")->string());
 
@@ -1005,18 +1077,39 @@ auto zpt::gen::rest::unit::generate_retrieve_element(zpt::ast::basic_file::ptr _
       .add<zpt::ast::cpp_variable>("_params", "zpt::json");
     auto _method_body = zpt::make_code_block<zpt::ast::cpp_code_block>();
 
-    _method_body //
-      ->add<zpt::ast::cpp_instruction>("auto _config = zpt::GLOBAL_CONFIG()")
-      .add<zpt::ast::cpp_instruction>(
-        std::format("auto _collection = _session->database({})->collection(\"{}\")",
-                    this->__schema("info")("database")->string(),
-                    _def("*")("requestBody")("dbCollection")->string()))
-      .add<zpt::ast::cpp_instruction>(
-        std::format("zpt::json _fields = {}", this->get_visible_fields(_def)))
-      .add<zpt::ast::cpp_instruction>("_fields << \"_id\"")
-      .add<zpt::ast::cpp_instruction>(this->remove_hidden_fields(_def))
-      .add<zpt::ast::cpp_instruction>("auto _result = zpt::storage::filter_find(_collection, "
-                                      "_params) //\n->fields(_fields)->execute()->fetch(1)");
+    if (_def("*")("requestBody")("dbCollection")->is_string()) {
+        _method_body //
+          ->add<zpt::ast::cpp_instruction>("auto _config = zpt::GLOBAL_CONFIG()")
+          .add<zpt::ast::cpp_instruction>(
+            std::format("auto _collection = _session->database({})->collection(\"{}\")",
+                        this->__schema("info")("database")->string(),
+                        _def("*")("requestBody")("dbCollection")->string()))
+          .add<zpt::ast::cpp_instruction>(
+            std::format("zpt::json _fields = {}", this->get_visible_fields(_def)))
+          .add<zpt::ast::cpp_instruction>("_fields << \"_id\"")
+          .add<zpt::ast::cpp_instruction>(this->remove_hidden_fields(_def))
+          .add<zpt::ast::cpp_instruction>("auto _result = zpt::storage::filter_find(_collection, "
+                                          "_params) //\n->fields(_fields)->execute()->fetch(1)");
+    }
+    else if (_def("*")("requestBody")("zpt:view")->is_string()) {
+        _method_body //
+          ->add<zpt::ast::cpp_instruction>("auto _config = zpt::GLOBAL_CONFIG()")
+          .add<zpt::ast::cpp_instruction>(
+            std::format("auto _collection = _session->database({})->collection(\"{}\")",
+                        this->__schema("info")("database")->string(),
+                        _def("*")("requestBody")("zpt:view")->string()))
+          .add<zpt::ast::cpp_instruction>("auto _result = zpt::storage::filter_find(_collection, "
+                                          "_params) //\n->execute()->fetch(1)");
+    }
+    else {
+        _method_body //
+          ->add<zpt::ast::cpp_instruction>("auto _config = zpt::GLOBAL_CONFIG()")
+          .add<zpt::ast::cpp_instruction>(std::format("auto _database = _session->database({})",
+                                                      this->__schema("info")("database")->string()))
+          .add<zpt::ast::cpp_instruction>(
+            "auto _result = _database //\n->sql(\"SQL STATEMENT HERE\")->fetch(1)");
+    }
+
     auto _if_block = zpt::make_code_block<zpt::ast::cpp_code_block>("if (_result->size() != 0)");
     _if_block //
       ->add<zpt::ast::cpp_instruction>("return _result(0)");
@@ -1099,7 +1192,8 @@ auto zpt::gen::rest::unit::generate_get_element(zpt::ast::basic_file::ptr _cpp_f
     this->add_parameters_and_validation(_method_body, _def, _path);
 
     auto _method_try_body = zpt::make_code_block<zpt::ast::cpp_code_block>("try");
-    if (_def("*")("requestBody")("dbCollection")->is_string()) {
+    if (_def("*")("requestBody")("dbCollection")->is_string() ||
+        _def("*")("requestBody")("zpt:view")->ok()) {
         _method_try_body //
           ->add<zpt::ast::cpp_instruction>(
             "auto _result = this->retrieve_element(_session, _params)");
@@ -1290,11 +1384,26 @@ auto zpt::gen::rest::unit::add_db_configuration(zpt::ast::basic_code_block::ptr 
         _block->add<zpt::ast::cpp_instruction>(
           "auto _session = zpt::make_connection<db_connection_type>(_config)->session()");
         if (_with_collection) {
-            _block-> //
-              add<zpt::ast::cpp_instruction>(
-                std::format("auto _collection = _session->database({})->collection(\"{}\")",
-                            this->__schema("info")("database")->string(),
-                            _def("*")("requestBody")("dbCollection")->string()));
+            if (_def("*")("requestBody")("dbCollection")->is_string()) {
+                _block-> //
+                  add<zpt::ast::cpp_instruction>(
+                    std::format("auto _collection = _session->database({})->collection(\"{}\")",
+                                this->__schema("info")("database")->string(),
+                                _def("*")("requestBody")("dbCollection")->string()));
+            }
+            else if (_def("*")("requestBody")("zpt:view")->is_string()) {
+                _block-> //
+                  add<zpt::ast::cpp_instruction>(
+                    std::format("auto _collection = _session->database({})->collection(\"{}\")",
+                                this->__schema("info")("database")->string(),
+                                _def("*")("requestBody")("zpt:view")->string()));
+            }
+            else {
+                _block-> //
+                  add<zpt::ast::cpp_instruction>(
+                    std::format("auto _database = _session->database({})",
+                                this->__schema("info")("database")->string()));
+            }
         }
     }
 }

--- a/network/transport/src/transport.cpp
+++ b/network/transport/src/transport.cpp
@@ -43,7 +43,14 @@ auto zpt::basic_transport::receive(zpt::stream _stream) const -> zpt::message {
         }
     }
     else { _to_return = this->process_incoming_request(_stream); }
-    zlog("Received message via '" << _stream->uri() << "': \n" << _to_return, zpt::trace);
+    zlog("Received message via '" << _stream->uri()
+                                  << "': " << zpt::ontology::to_str(_to_return->performative())
+                                  << " " << zpt::uri::to_string(_to_return->uri()) << " -> "
+                                  << (_to_return->performative() == zpt::Reply
+                                        ? std::to_string(_to_return->status()) + " "
+                                        : "")
+                                  << _to_return->body(),
+         zpt::trace);
     return _to_return;
 }
 
@@ -57,7 +64,14 @@ auto zpt::basic_transport::send(zpt::stream _stream, zpt::message _to_send) cons
                  _stream->state() == zpt::stream_state::ERRORING_OUT,
                "Stream not in a valid state for sending");
     }
-    zlog("Sending message via '" << _stream->uri() << "' : \n" << _to_send, zpt::trace);
+    zlog("Sending message via '" << _stream->uri()
+                                 << "': " << zpt::ontology::to_str(_to_send->performative()) << " "
+                                 << zpt::uri::to_string(_to_send->uri()) << " -> "
+                                 << (_to_send->performative() == zpt::Reply
+                                       ? std::to_string(_to_send->status()) + " "
+                                       : "")
+                                 << _to_send->body(),
+         zpt::trace);
 
     _stream->write<zpt::message>(_to_send);
 

--- a/storage/connector/include/zapata/connector/connector.h
+++ b/storage/connector/include/zapata/connector/connector.h
@@ -134,7 +134,7 @@ class session {
         /** @brief Returns true if session is open. */
         virtual auto is_open() const -> bool = 0;
         /** @brief Executes raw SQL statement. */
-        virtual auto sql(std::string const& _statement) -> zpt::storage::session::type* = 0;
+        virtual auto sql(std::string const& _statement) -> zpt::storage::result = 0;
         /** @brief Commits the current transaction. */
         virtual auto commit() -> zpt::storage::session::type* = 0;
         /** @brief Rolls back the current transaction. */
@@ -182,7 +182,7 @@ class database {
         virtual ~type() = default;
 
         /** @brief Executes raw SQL statement. */
-        virtual auto sql(std::string const& _statement) -> zpt::storage::database::type* = 0;
+        virtual auto sql(std::string const& _statement) -> zpt::storage::result = 0;
         /** @brief Gets a collection/table by name. */
         virtual auto collection(std::string const& _name) const -> zpt::storage::collection = 0;
     };

--- a/storage/mongodb/include/zapata/mongodb/connector.h
+++ b/storage/mongodb/include/zapata/mongodb/connector.h
@@ -114,7 +114,7 @@ class session : public zpt::storage::session::type {
     /** @brief No-op for MongoDB (transactions require replica sets). */
     virtual auto rollback() -> zpt::storage::session::type* override;
     /** @brief Not supported for MongoDB; always throws. */
-    virtual auto sql(std::string const& _statement) -> zpt::storage::session::type* override;
+    virtual auto sql(std::string const& _statement) -> zpt::storage::result override;
     /** @brief Selects a database within this session. */
     virtual auto database(std::string const& _db) const -> zpt::storage::database override;
 
@@ -135,7 +135,7 @@ class database : public zpt::storage::database::type {
     /** @brief Destructor. */
     virtual ~database() override = default;
     /** @brief Not supported for MongoDB; always throws. */
-    virtual auto sql(std::string const& _statement) -> zpt::storage::database::type* override;
+    virtual auto sql(std::string const& _statement) -> zpt::storage::result override;
     /** @brief Returns a collection handle for the given name. */
     virtual auto collection(std::string const& _name) const -> zpt::storage::collection override;
 
@@ -438,6 +438,8 @@ class action_find : public zpt::storage::mongodb::action {
 /** @brief MongoDB query result set. */
 class result : public zpt::storage::result::type {
   public:
+    /** @brief Constructs a result from a cursor. */
+    result(mongodb_cursor_ptr __cursor);
     /** @brief Constructs a result from a generic action (cursor and client only). */
     result(zpt::storage::mongodb::action& _action);
     /** @brief Constructs a result from an insert action, capturing generated IDs. */

--- a/storage/mongodb/src/connector.cpp
+++ b/storage/mongodb/src/connector.cpp
@@ -101,9 +101,10 @@ auto zpt::storage::mongodb::session::commit() -> zpt::storage::session::type* { 
 auto zpt::storage::mongodb::session::rollback() -> zpt::storage::session::type* { return this; }
 
 auto zpt::storage::mongodb::session::sql([[maybe_unused]] std::string const& _statement)
-  -> zpt::storage::session::type* {
+  -> zpt::storage::result {
     expect(false, "SQL is not supported for MongoDB");
-    return this;
+    mongodb_cursor_ptr _cursor{ nullptr };
+    return zpt::make_result<zpt::storage::mongodb::result>(_cursor);
 }
 
 auto zpt::storage::mongodb::session::database(std::string const& _db) const
@@ -121,9 +122,10 @@ zpt::storage::mongodb::database::database(zpt::storage::mongodb::session const& 
   , __db{ _db } {}
 
 auto zpt::storage::mongodb::database::sql([[maybe_unused]] std::string const& _statement)
-  -> zpt::storage::database::type* {
+  -> zpt::storage::result {
     expect(false, "SQL is not supported for MongoDB");
-    return this;
+    mongodb_cursor_ptr _cursor{ nullptr };
+    return zpt::make_result<zpt::storage::mongodb::result>(_cursor);
 }
 
 auto zpt::storage::mongodb::database::collection(std::string const& _collection) const
@@ -661,9 +663,11 @@ auto zpt::storage::mongodb::action_find::execute() -> zpt::storage::result {
 }
 
 // ---- result ----
+zpt::storage::mongodb::result::result(mongodb_cursor_ptr _cursor)
+  : __cursor{ _cursor } {}
 
 zpt::storage::mongodb::result::result(zpt::storage::mongodb::action& _action)
-  : __cursor{ _action.cursor() } {}
+  : zpt::storage::mongodb::result{ _action.cursor() } {}
 
 zpt::storage::mongodb::result::result(zpt::storage::mongodb::action_add& _action)
   : zpt::storage::mongodb::result{ static_cast<zpt::storage::mongodb::action&>(_action) } {

--- a/storage/mysqlx/examples/mysqlx.cpp
+++ b/storage/mysqlx/examples/mysqlx.cpp
@@ -8,7 +8,8 @@ auto main(int, char**) -> int {
     _session->sql("create table if not exists test.users (_id varchar(36) primary key, name TEXT, "
                   "address TEXT)");
 
-    auto _collection = _session->database("test")->collection("users");
+    auto _database = _session->database("test");
+    auto _collection = _database->collection("users");
     _collection //
       ->remove({})
       ->execute();
@@ -21,6 +22,16 @@ auto main(int, char**) -> int {
     std::cout << _collection //
                    ->find(std::format("_id = \"{}\"", _ids(0)->string()))
                    ->execute()
+                   ->fetch()
+              << std::endl;
+
+    std::cout << _session //
+                   ->sql("select * from test.users where address like '%Down%'")
+                   ->fetch()
+              << std::endl;
+
+    std::cout << _database //
+                   ->sql("select * from users where address like '%Down%'")
                    ->fetch()
               << std::endl;
 

--- a/storage/mysqlx/include/zapata/mysqlx/connector.h
+++ b/storage/mysqlx/include/zapata/mysqlx/connector.h
@@ -125,7 +125,7 @@ class session : public zpt::storage::session::type {
     /** @brief Rolls back the current transaction. */
     virtual auto rollback() -> zpt::storage::session::type* override;
     /** @brief Executes a raw SQL statement on this session. */
-    virtual auto sql(std::string const& _statement) -> zpt::storage::session::type* override;
+    virtual auto sql(std::string const& _statement) -> zpt::storage::result override;
     /** @brief Selects a database (schema) within this session. */
     virtual auto database(std::string const& _db) const -> zpt::storage::database override;
 
@@ -145,7 +145,7 @@ class database : public zpt::storage::database::type {
     /** @brief Destructor. */
     virtual ~database() override = default;
     /** @brief Executes a raw SQL statement on this database. */
-    virtual auto sql(std::string const& _statement) -> zpt::storage::database::type* override;
+    virtual auto sql(std::string const& _statement) -> zpt::storage::result override;
     /** @brief Returns a collection (table) handle for the given name. */
     virtual auto collection(std::string const& _name) const -> zpt::storage::collection override;
 
@@ -430,7 +430,9 @@ class action_find : public zpt::storage::mysqlx::action {
 /** @brief MySQL query result set. */
 class result : public zpt::storage::result::type {
   public:
-    /** @brief Constructs a result from a generic action (executes the statement). */
+    /** @brief Constructs a result from the structures resulting from an SQL execution. */
+    result(mysql_ptr _mysql, mysql_stmt_ptr _statement);
+    /** @brief Constructs a result from a generic action. */
     result(zpt::storage::mysqlx::action& _action);
     /** @brief Constructs a result from an INSERT action, capturing generated IDs. */
     result(zpt::storage::mysqlx::action_add& _action);

--- a/storage/mysqlx/src/connector.cpp
+++ b/storage/mysqlx/src/connector.cpp
@@ -119,8 +119,7 @@ auto zpt::storage::mysqlx::session::rollback() -> zpt::storage::session::type* {
     return this;
 }
 
-auto zpt::storage::mysqlx::session::sql(std::string const& _statement)
-  -> zpt::storage::session::type* {
+auto zpt::storage::mysqlx::session::sql(std::string const& _statement) -> zpt::storage::result {
     mysql_stmt_ptr _to_exec{ mysql_stmt_init(this->__mysql.get()),
                              zpt::storage::mysqlx::mysql_stmt_end{} };
     expect(0 == mysql_stmt_prepare(_to_exec.get(), _statement.data(), _statement.length()),
@@ -129,7 +128,9 @@ auto zpt::storage::mysqlx::session::sql(std::string const& _statement)
     expect(0 == mysql_stmt_execute(_to_exec.get()),
            std::format(
              "failed to execute statement '{}': {}", _statement, mysql_error(this->__mysql.get())));
-    return this;
+    zpt::storage::result _to_return =
+      zpt::make_result<zpt::storage::mysqlx::result>(this->__mysql, _to_exec);
+    return _to_return;
 }
 
 auto zpt::storage::mysqlx::session::database(std::string const& _db) const
@@ -149,9 +150,18 @@ zpt::storage::mysqlx::database::database(zpt::storage::mysqlx::session const& _s
              "failed to execute statement '{}': {}", _statement, mysql_error(this->__mysql.get())));
 }
 
-auto zpt::storage::mysqlx::database::sql(std::string const&) -> zpt::storage::database::type* {
-    expect(false, "database `sql` method not implemented for MySQL XDevAPI, use session's");
-    return this;
+auto zpt::storage::mysqlx::database::sql(std::string const& _statement) -> zpt::storage::result {
+    mysql_stmt_ptr _to_exec{ mysql_stmt_init(this->__mysql.get()),
+                             zpt::storage::mysqlx::mysql_stmt_end{} };
+    expect(0 == mysql_stmt_prepare(_to_exec.get(), _statement.data(), _statement.length()),
+           std::format(
+             "failed to prepare statement '{}': {}", _statement, mysql_error(this->__mysql.get())));
+    expect(0 == mysql_stmt_execute(_to_exec.get()),
+           std::format(
+             "failed to execute statement '{}': {}", _statement, mysql_error(this->__mysql.get())));
+    zpt::storage::result _to_return =
+      zpt::make_result<zpt::storage::mysqlx::result>(this->__mysql, _to_exec);
+    return _to_return;
 }
 
 auto zpt::storage::mysqlx::database::collection(std::string const& _collection) const
@@ -732,13 +742,16 @@ auto zpt::storage::mysqlx::action_find::execute() -> zpt::storage::result {
     return _to_return;
 }
 
-zpt::storage::mysqlx::result::result(zpt::storage::mysqlx::action& _action)
-  : __mysql{ _action.mysql() }
-  , __statement{ _action.statement() }
-  , __metadata{ _action.statement().get() } {
+zpt::storage::mysqlx::result::result(mysql_ptr _mysql, mysql_stmt_ptr _statement)
+  : __mysql{ _mysql }
+  , __statement{ _statement }
+  , __metadata{ _statement.get() } {
     mysql_stmt_bind_result(this->__statement.get(), this->__metadata.__bind.get());
     mysql_stmt_store_result(this->__statement.get());
 }
+
+zpt::storage::mysqlx::result::result(zpt::storage::mysqlx::action& _action)
+  : zpt::storage::mysqlx::result{ _action.mysql(), _action.statement() } {}
 
 zpt::storage::mysqlx::result::result(zpt::storage::mysqlx::action_add& _action)
   : zpt::storage::mysqlx::result{ static_cast<zpt::storage::mysqlx::action&>(_action) } {

--- a/storage/pgsql/examples/pgsql.cpp
+++ b/storage/pgsql/examples/pgsql.cpp
@@ -7,8 +7,8 @@ auto main(int, char**) -> int {
     _session->sql("create schema if not exists test");
     _session->sql("create table if not exists test.users (_id varchar(36) primary key, name TEXT, "
                   "address TEXT)");
-
-    auto _collection = _session->database("test")->collection("users");
+    auto _database = _session->database("test");
+    auto _collection = _database->collection("users");
     _collection //
       ->remove({})
       ->execute();
@@ -21,6 +21,16 @@ auto main(int, char**) -> int {
     std::cout << _collection //
                    ->find(std::format("_id = {}", zpt::storage::pgsql::quote(_ids(0)->string())))
                    ->execute()
+                   ->fetch()
+              << std::endl;
+
+    std::cout << _session //
+                   ->sql("select * from test.users where address like '%Down%'")
+                   ->fetch()
+              << std::endl;
+
+    std::cout << _database //
+                   ->sql("select * from users where address like '%Down%'")
                    ->fetch()
               << std::endl;
 

--- a/storage/pgsql/include/zapata/pgsql/connector.h
+++ b/storage/pgsql/include/zapata/pgsql/connector.h
@@ -120,7 +120,7 @@ class session : public zpt::storage::session::type {
     /** @brief Rolls back the current transaction. */
     virtual auto rollback() -> zpt::storage::session::type* override;
     /** @brief Executes a raw SQL statement on this session. */
-    virtual auto sql(std::string const& _statement) -> zpt::storage::session::type* override;
+    virtual auto sql(std::string const& _statement) -> zpt::storage::result override;
     /** @brief Selects a database (schema) within this session. */
     virtual auto database(std::string const& _db) const -> zpt::storage::database override;
 
@@ -140,7 +140,7 @@ class database : public zpt::storage::database::type {
     /** @brief Destructor. */
     virtual ~database() override = default;
     /** @brief Executes a raw SQL statement on this database. */
-    virtual auto sql(std::string const& _statement) -> zpt::storage::database::type* override;
+    virtual auto sql(std::string const& _statement) -> zpt::storage::result override;
     /** @brief Returns a collection (table) handle for the given name. */
     virtual auto collection(std::string const& _name) const -> zpt::storage::collection override;
 
@@ -431,6 +431,8 @@ class action_find : public zpt::storage::pgsql::action {
 /** @brief PostgreSQL query result set. */
 class result : public zpt::storage::result::type {
   public:
+    /** @brief Constructs a result from the structures resulting from an SQL execution. */
+    result(pgsql_ptr _pgsql, pgsql_result_ptr _result);
     /** @brief Constructs a result from a generic action (executes the statement). */
     result(zpt::storage::pgsql::action& _action);
     /** @brief Constructs a result from an INSERT action, capturing generated IDs. */

--- a/storage/pgsql/src/connector.cpp
+++ b/storage/pgsql/src/connector.cpp
@@ -144,8 +144,7 @@ auto zpt::storage::pgsql::session::rollback() -> zpt::storage::session::type* {
     return this;
 }
 
-auto zpt::storage::pgsql::session::sql(std::string const& _statement)
-  -> zpt::storage::session::type* {
+auto zpt::storage::pgsql::session::sql(std::string const& _statement) -> zpt::storage::result {
     auto* _res = PQexec(this->__pgsql.get(), _statement.c_str());
     auto _ok = PQresultStatus(_res) == PGRES_COMMAND_OK || PQresultStatus(_res) == PGRES_TUPLES_OK;
     if (!_ok) {
@@ -153,8 +152,12 @@ auto zpt::storage::pgsql::session::sql(std::string const& _statement)
         PQclear(_res);
         expect(false, std::format("SQL failed: {} — {}", _err, _statement));
     }
-    PQclear(_res);
-    return this;
+
+    pgsql_result_ptr _result{ _res, zpt::storage::pgsql::pgsql_result_deinit{} };
+
+    zpt::storage::result _to_return =
+      zpt::make_result<zpt::storage::pgsql::result>(this->__pgsql, _result);
+    return _to_return;
 }
 
 auto zpt::storage::pgsql::session::database(std::string const& _db) const
@@ -169,11 +172,31 @@ auto zpt::storage::pgsql::session::pgsql() const -> pgsql_ptr { return this->__p
 zpt::storage::pgsql::database::database(zpt::storage::pgsql::session const& _session,
                                         std::string const& _db)
   : __pgsql{ _session.pgsql() }
-  , __schema{ _db } {}
+  , __schema{ _db } {
+    auto* _res = PQexec(
+      this->__pgsql.get(),
+      std::format("SET search_path TO {}", zpt::storage::pgsql::quote(this->__schema)).data());
+    auto _ok = PQresultStatus(_res) == PGRES_COMMAND_OK;
+    PQclear(_res);
+    expect(_ok,
+           std::format("Failed to set search path to current database: {}",
+                       PQerrorMessage(this->__pgsql.get())));
+}
 
-auto zpt::storage::pgsql::database::sql(std::string const&) -> zpt::storage::database::type* {
-    expect(false, "database `sql` method not implemented for PostgreSQL, use session's");
-    return this;
+auto zpt::storage::pgsql::database::sql(std::string const& _statement) -> zpt::storage::result {
+    auto* _res = PQexec(this->__pgsql.get(), _statement.c_str());
+    auto _ok = PQresultStatus(_res) == PGRES_COMMAND_OK || PQresultStatus(_res) == PGRES_TUPLES_OK;
+    if (!_ok) {
+        auto _err = std::string{ PQerrorMessage(this->__pgsql.get()) };
+        PQclear(_res);
+        expect(false, std::format("SQL failed: {} — {}", _err, _statement));
+    }
+
+    pgsql_result_ptr _result{ _res, zpt::storage::pgsql::pgsql_result_deinit{} };
+
+    zpt::storage::result _to_return =
+      zpt::make_result<zpt::storage::pgsql::result>(this->__pgsql, _result);
+    return _to_return;
 }
 
 auto zpt::storage::pgsql::database::collection(std::string const& _collection) const
@@ -771,9 +794,12 @@ auto zpt::storage::pgsql::action_find::execute() -> zpt::storage::result {
 
 // ---- result ----
 
+zpt::storage::pgsql::result::result(pgsql_ptr _pgsql, pgsql_result_ptr _result)
+  : __pgsql{ _pgsql }
+  , __result{ _result } {}
+
 zpt::storage::pgsql::result::result(zpt::storage::pgsql::action& _action)
-  : __pgsql{ _action.pgsql() }
-  , __result{ _action.result() } {}
+  : zpt::storage::pgsql::result{ _action.pgsql(), _action.result() } {}
 
 zpt::storage::pgsql::result::result(zpt::storage::pgsql::action_add& _action)
   : zpt::storage::pgsql::result{ static_cast<zpt::storage::pgsql::action&>(_action) } {

--- a/storage/sqlite/examples/sqlite.cpp
+++ b/storage/sqlite/examples/sqlite.cpp
@@ -21,6 +21,10 @@ auto main(int, char**) -> int {
         _id2.assign(_result->to_json()("generated")(0)->string());
         zlog("---- There are " << _collection->count() << " records in the collection.", zpt::info);
     }
+    std::cout << _database //
+                   ->sql("select * from users")
+                   ->fetch()
+              << std::endl;
     {
         auto _result = _collection //
                          ->find({})
@@ -96,5 +100,6 @@ auto main(int, char**) -> int {
                          ->execute();
         zlog("---- Collection elements: " << zpt::json::pretty(_result->fetch()), zpt::info);
     }
+
     return 0;
 }

--- a/storage/sqlite/include/zapata/sqlite/connector.h
+++ b/storage/sqlite/include/zapata/sqlite/connector.h
@@ -117,7 +117,7 @@ class session : public zpt::storage::session::type {
     /** @brief Rolls back the current transaction on all underlying SQLite connections. */
     virtual auto rollback() -> zpt::storage::session::type* override;
     /** @brief Executes a raw SQL statement directly on the session's connections. */
-    virtual auto sql(std::string const& _statement) -> zpt::storage::session::type* override;
+    virtual auto sql(std::string const& _statement) -> zpt::storage::result override;
     /** @brief Selects and returns the named database (SQLite file) within this session. */
     virtual auto database(std::string const& _db) const -> zpt::storage::database override;
     /** @brief Registers an additional SQLite database handle with this session. */
@@ -138,7 +138,7 @@ class database : public zpt::storage::database::type {
     database(zpt::storage::sqlite::database&& _rhs) = delete;
     virtual ~database() override = default;
     /** @brief Executes a raw SQL statement directly against the SQLite database file. */
-    virtual auto sql(std::string const& _statement) -> zpt::storage::database::type* override;
+    virtual auto sql(std::string const& _statement) -> zpt::storage::result override;
     /** @brief Returns a collection (table) accessor for the given table name. */
     virtual auto collection(std::string const& _name) const -> zpt::storage::collection override;
     /** @brief Returns the underlying sqlite3 handle for this database. */

--- a/storage/sqlite/src/connector.cpp
+++ b/storage/sqlite/src/connector.cpp
@@ -218,9 +218,9 @@ auto zpt::storage::sqlite::session::rollback() -> zpt::storage::session::type* {
     return this;
 }
 
-auto zpt::storage::sqlite::session::sql(std::string const&) -> zpt::storage::session::type* {
+auto zpt::storage::sqlite::session::sql(std::string const&) -> zpt::storage::result {
     expect(false, "Session `sql` method not implemented for SQLite, use database's");
-    return this;
+    return zpt::make_result<zpt::storage::sqlite::result>(zpt::undefined);
 }
 
 auto zpt::storage::sqlite::session::database(std::string const& _db) const
@@ -249,8 +249,8 @@ zpt::storage::sqlite::database::database(zpt::storage::sqlite::session const& _s
       this->__underlying);
 }
 
-auto zpt::storage::sqlite::database::sql(std::string const& _to_execute)
-  -> zpt::storage::database::type* {
+auto zpt::storage::sqlite::database::sql(std::string const& _to_execute) -> zpt::storage::result {
+    std::vector<sqlite3_stmt_ptr> _prepared;
     sqlite3_stmt* _stmt{ nullptr };
     sqlite_expect(
       sqlite3_prepare_v2(
@@ -258,9 +258,10 @@ auto zpt::storage::sqlite::database::sql(std::string const& _to_execute)
       "unable to prepare statement: " << sqlite3_errmsg(this->__underlying.get()));
     sqlite_expect(sqlite3_step(_stmt),
                   "unable to execute statement: " << sqlite3_errmsg(this->__underlying.get()));
-    sqlite_expect(sqlite3_finalize(_stmt),
-                  "unable to cleanup statement: " << sqlite3_errmsg(this->__underlying.get()));
-    return this;
+    _prepared.push_back(sqlite3_stmt_ptr{ _stmt, zpt::storage::sqlite::finalize_statement{} });
+
+    zpt::json _result{ "state", zpt::json::object(), "generated", zpt::json::array() };
+    return zpt::make_result<zpt::storage::sqlite::result>(_result, _prepared);
 }
 
 auto zpt::storage::sqlite::database::connection() const -> sqlite3_ptr {


### PR DESCRIPTION
- The `connector::sql(std::string _statement)` returns` a result-set.
- Introduction of `zpt:view` in JSON schema `requestBody`, which will
  generate a read-only resource accessing either a view or a the result
  of SQL execution.