### PR TITLE
Refining stream re-use and `zpt::events::call` life-cycle

### DIFF
--- a/common/base/include/zapata/uuid.h
+++ b/common/base/include/zapata/uuid.h
@@ -75,6 +75,10 @@ class uuid {
     uuid(uuid&& _rhs);
     ~uuid() = default;
     /**
+     * @brief Retrieves the unsigned 128-bit integer representing this UUID.
+     */
+    operator __uint128_t() const;
+    /**
      * @brief Copy assignment operator.
      * @param _rhs UUID to copy.
      * @return Reference to this UUID.
@@ -175,5 +179,21 @@ class uuid {
   private:
     __uint128_t __base; ///< 128-bit UUID value.
 };
-
 } // namespace zpt
+
+namespace std {
+/**
+ * @brief std::hash specialization for zpt::uuid.
+ *
+ * Enables using UUID values as keys in unordered containers.
+ *
+ * @par Example
+ * @code
+ * std::unordered_map<zpt::uuid, int> cache;
+ * @endcode
+ */
+template<>
+struct hash<zpt::uuid> {
+    auto operator()(zpt::uuid const& _uuid) const noexcept -> std::size_t;
+};
+} // namespace std

--- a/common/base/src/uuid.cpp
+++ b/common/base/src/uuid.cpp
@@ -44,6 +44,8 @@ zpt::uuid::uuid(uuid&& _rhs)
     _rhs.__base = 0;
 }
 
+zpt::uuid::operator __uint128_t() const { return this->__base; }
+
 auto zpt::uuid::operator=(__uint128_t _rhs) -> uuid& {
     this->__base = _rhs;
     return (*this);
@@ -151,4 +153,9 @@ auto zpt::uuid::from_stream(std::istream& _in) -> uuid& {
     }
 
     return (*this);
+}
+
+auto std::hash<zpt::uuid>::operator()(zpt::uuid const& _uuid) const noexcept -> std::size_t {
+    __uint128_t _base = static_cast<__uint128_t>(_uuid);
+    return static_cast<std::uint64_t>(_base) ^ static_cast<std::uint64_t>(_base >> 64);
 }

--- a/engines/transport/include/zapata/transport/engine.h
+++ b/engines/transport/include/zapata/transport/engine.h
@@ -27,6 +27,12 @@
 #include <zapata/transport.h>
 #include <zapata/uuid.h>
 
+namespace {
+constexpr unsigned int IS_SELF = 1;
+constexpr unsigned int IS_EXTERNAL = 2;
+constexpr unsigned int HAS_PUB_SUB = 3;
+} // namespace
+
 namespace zpt {
 namespace transports {
 
@@ -340,10 +346,12 @@ class call {
     zpt::polling::ptr __polling{ nullptr };
     zpt::message __to_send{ nullptr };
     zpt::call_context::ptr __context{ nullptr };
+    bool __resolved{ false };
 
-    auto call_internally() -> call&;
-    auto send_externally() -> call&;
-    auto publish_externally() -> call&;
+    auto resolve_uri() -> unsigned int;
+    auto call_internally() -> zpt::events::state;
+    auto send_externally() -> zpt::events::state;
+    auto publish_externally() -> zpt::events::state;
 };
 
 /**
@@ -383,6 +391,9 @@ zpt::events::call<T>::call(zpt::events::resolver _resolver,
   , __context{ _context } {
     if (!this->__to_send->headers()("X-Conversation-ID")->ok()) {
         this->__to_send->headers()["X-Conversation-ID"] = zpt::uuid{}.to_string();
+    }
+    if (!this->__to_send->headers()("Content-type")->ok()) {
+        this->__to_send->header("Content-Type", "application/json");
     }
 }
 
@@ -426,6 +437,35 @@ auto zpt::events::call<T>::catch_error(zpt::failed_expectation const&, zpt::even
 
 template<ProcessOperation T>
 auto zpt::events::call<T>::operator()(zpt::events::dispatcher::ptr) -> zpt::events::state {
+    unsigned int _which{ 0 };
+    try {
+        _which = this->resolve_uri();
+    }
+    catch (...) {
+        auto _reply = zpt::make_message<zpt::json_message>(this->__to_send, true);
+        _reply->status(404);
+        this->__context->reply(_reply);
+        return zpt::events::finish;
+    }
+
+    switch (_which) {
+        case ::HAS_PUB_SUB: {
+            return this->publish_externally();
+        }
+        case ::IS_SELF: {
+            return this->call_internally();
+        }
+        default: {
+            return this->send_externally();
+        }
+    }
+    return zpt::events::finish;
+}
+
+template<ProcessOperation T>
+auto zpt::events::call<T>::resolve_uri() -> unsigned int {
+    if (this->__resolved) { return ::IS_EXTERNAL; }
+
     auto& _uri = this->__to_send->uri();
     expect(_uri("path")->ok(), "Can't send a message without a resource path");
 
@@ -434,8 +474,7 @@ auto zpt::events::call<T>::operator()(zpt::events::dispatcher::ptr) -> zpt::even
         auto _transport = zpt::TRANSPORT_LAYER().get(_uri("scheme")->string());
 
         if (_transport->has_capability(zpt::transport_capability::PUB_SUB)) {
-            this->publish_externally();
-            return zpt::events::finish;
+            return ::HAS_PUB_SUB;
         }
         if (_transport->has_capability(zpt::transport_capability::UPGRADED)) {
             _upgraded_from_scheme = _transport->upgraded_from();
@@ -444,106 +483,93 @@ auto zpt::events::call<T>::operator()(zpt::events::dispatcher::ptr) -> zpt::even
 
     bool _is_self{ false };
     if (!_uri("scheme")->ok() || !_uri("domain")->ok() || !_uri("port")->ok()) {
-        try {
-            auto _found = this->__resolver->search(
-              std::format("/{}{}",
-                          zpt::ontology::to_str(this->__to_send->performative()),
-                          _uri("raw_path")->string()));
-            expect(_found->ok() && _found->size() != 0,
-                   "Couldn't find a provider of '" << _uri("path")->string());
+        auto _found = this->__resolver->search(
+          std::format("/{}{}",
+                      zpt::ontology::to_str(this->__to_send->performative()),
+                      _uri("raw_path")->string()));
+        expect(_found->ok() && _found->size() != 0,
+               "Couldn't find a provider of '" << _uri("path")->string());
 
-            for (auto&& [_, __, _service] : _found) {
-                if ((_is_self = (_service("provider_id") == zpt::IDENTITY()("_id")))) { break; }
-            }
-
-            if (!_is_self) {
-                auto _provider = this->__resolver->get_provider(_found(0)("provider_id")->string());
-                expect(_provider->ok() && _provider->size() != 0,
-                       "Couldn't find a provider of '" << _uri("path")->string());
-                if (!_uri("scheme")->ok()) {
-                    _uri["scheme"] = _provider(0)("protocols")("default");
-                }
-                auto _scheme =
-                  _upgraded_from_scheme.empty() ? _uri("scheme")->string() : _upgraded_from_scheme;
-                _uri["domain"] = _provider(0)("protocols")("registered")(_scheme)("address");
-                _uri["port"] = _provider(0)("protocols")("registered")(_scheme)("port");
-            }
+        for (auto&& [_, __, _service] : _found) {
+            if ((_is_self = (_service("provider_id") == zpt::IDENTITY()("_id")))) { break; }
         }
-        catch (...) {
-            auto _reply = zpt::make_message<zpt::json_message>(this->__to_send, true);
-            _reply->status(404);
-            this->__context->reply(_reply);
-            return zpt::events::finish;
+
+        if (!_is_self) {
+            auto _provider = this->__resolver->get_provider(_found(0)("provider_id")->string());
+            expect(_provider->ok() && _provider->size() != 0,
+                   "Couldn't find a provider of '" << _uri("path")->string());
+            if (!_uri("scheme")->ok()) { _uri["scheme"] = _provider(0)("protocols")("default"); }
+            auto _scheme =
+              _upgraded_from_scheme.empty() ? _uri("scheme")->string() : _upgraded_from_scheme;
+            _uri["domain"] = _provider(0)("protocols")("registered")(_scheme)("address");
+            _uri["port"] = _provider(0)("protocols")("registered")(_scheme)("port");
         }
     }
 
-    if (_is_self) { this->call_internally(); }
-    else { this->send_externally(); }
+    return _is_self ? ::IS_SELF : ::IS_EXTERNAL;
+}
+
+template<ProcessOperation T>
+auto zpt::events::call<T>::call_internally() -> zpt::events::state {
+    if (!this->__resolved) {
+        this->__resolver->add(this->__to_send, this->__context, zpt::events::make_callback<T>);
+        this->__resolved = true;
+    }
+
+    auto _transport = zpt::TRANSPORT_LAYER() //
+                        .get("self");
+    auto _stream = zpt::allocate_shared<zpt::event_stream>();
+    this->__polling->listen_on(_stream);
+    _transport->send(_stream, this->__to_send);
 
     return zpt::events::finish;
 }
 
 template<ProcessOperation T>
-auto zpt::events::call<T>::call_internally() -> call& {
-    this->__resolver->add(this->__to_send, this->__context, zpt::events::make_callback<T>);
-
-    auto _transport = zpt::TRANSPORT_LAYER() //
-                        .get("self");
-    auto _stream = zpt::allocate_shared<zpt::event_stream>();
-    this->__to_send->header("Content-Type", "application/json");
-    this->__polling->listen_on(_stream);
-    _transport->send(_stream, this->__to_send);
-
-    return (*this);
-}
-
-template<ProcessOperation T>
-auto zpt::events::call<T>::send_externally() -> call& {
+auto zpt::events::call<T>::send_externally() -> zpt::events::state {
     auto& _uri = this->__to_send->uri();
     auto _scheme = _uri("scheme")->string();
     auto _transport = zpt::TRANSPORT_LAYER() //
                         .get(_scheme);
-    if (_transport->has_capability(zpt::transport_capability::SYNCHRONOUS)) {
-        this->__resolver->add(this->__to_send, this->__context, zpt::events::make_callback<T>);
+
+    if (!this->__resolved) {
+        if (_transport->has_capability(zpt::transport_capability::SYNCHRONOUS)) {
+            this->__resolver->add(this->__to_send, this->__context, zpt::events::make_callback<T>);
+        }
+        this->__resolved = true;
     }
 
     auto _host = _uri("domain")->string();
     auto _port = _uri("port")->integer();
-    this->__to_send->header("Content-Type", "application/json");
-
     zpt::stream _stream{ nullptr };
-    while (!this->__polling->is_in_shutdown()) {
-        try {
-            _stream = this->__polling->mute(std::format("{}://{}:{}", _scheme, _host, _port));
-            break;
-        }
-        catch (zpt::NoSuchElementException const& _e) {
-            _stream =
-              zpt::make_stream<zpt::socketstream>(_scheme, _host, _port, zpt::NO_SSL, IPPROTO_TCP);
-            this
-              ->__polling //
-              ->listen_on(_stream)
-              .mute(_stream);
-            break;
-        }
-        catch (zpt::failed_expectation const& _e) {
-        }
-        std::this_thread::yield();
+    try {
+        _stream = this->__polling->mute(std::format("{}://{}:{}", _scheme, _host, _port));
+    }
+    catch (zpt::NoSuchElementException const& _e) {
+        _stream =
+          zpt::make_stream<zpt::socketstream>(_scheme, _host, _port, zpt::NO_SSL, IPPROTO_TCP);
+        this
+          ->__polling //
+          ->listen_on(_stream)
+          .mute(_stream);
+    }
+    catch (zpt::failed_expectation const& _e) {
+        return zpt::events::retrigger;
     }
 
     _transport->send(_stream, this->__to_send);
     this->__polling->unmute(_stream);
 
-    return (*this);
+    return zpt::events::finish;
 }
 
 template<ProcessOperation T>
-auto zpt::events::call<T>::publish_externally() -> call& {
+auto zpt::events::call<T>::publish_externally() -> zpt::events::state {
+    this->__resolved = true;
     auto _transport = zpt::TRANSPORT_LAYER() //
                         .get(this->__to_send->uri()("scheme")->string());
-    this->__to_send->header("Content-Type", "application/json");
     _transport->publish(this->__to_send);
-    return (*this);
+    return zpt::events::finish;
 }
 
 template<ProcessOperation T>

--- a/engines/transport/src/engine.cpp
+++ b/engines/transport/src/engine.cpp
@@ -92,7 +92,7 @@ auto zpt::events::receive::check_upgrade(zpt::message _received) -> bool {
 
         if (_received->performative() == zpt::Reply) {
             expect(_received->status() == 101, "Server didn't comply with the upgrade request");
-            _received->body() = { "stream", this->__stream->uuid() };
+            _received->body() = { "stream", this->__stream->uuid().to_string() };
 
             if (_value == "websocket") { _value = "ws"; }
             this->__polling->upgrade(this->__stream, _value);

--- a/io/stream/include/zapata/streams/streams.h
+++ b/io/stream/include/zapata/streams/streams.h
@@ -197,6 +197,9 @@ using stream = std::shared_ptr<zpt::basic_stream>;
 class polling : public std::enable_shared_from_this<polling> {
   public:
     using ptr = std::shared_ptr<polling>;
+    using polled_streams_type = std::unordered_map<int, zpt::stream>;
+    using polled_streams_by_uuid_type = std::unordered_map<zpt::uuid, zpt::stream>;
+    using polled_streams_by_uri_type = std::unordered_map<std::string, zpt::stream>;
     /** @brief Delegate function signature: returns true to keep stream, false to remove. */
     using delegate_fn_type = std::function<bool(zpt::polling::ptr _poll, zpt::stream _stream)>;
     /** @brief Maximum events processed per poll() call. */
@@ -237,11 +240,11 @@ class polling : public std::enable_shared_from_this<polling> {
     /** @brief Mutex protecting the polled streams map. */
     mutable zpt::locks::spin_mutex __poll_lock;
     /** @brief Map of file descriptors to stream pointers currently being monitored. */
-    std::map<int, zpt::stream> __polled_streams;
+    polled_streams_type __polled_streams;
     /** @brief Map of file descriptors to stream pointers currently being monitored. */
-    std::map<zpt::uuid, zpt::stream> __polled_streams_by_uuid;
+    polled_streams_by_uuid_type __polled_streams_by_uuid;
     /** @brief Map of file descriptors to stream pointers currently being monitored. */
-    std::map<std::string, zpt::stream> __polled_streams_by_uri;
+    polled_streams_by_uri_type __polled_streams_by_uri;
     /** @brief List of delegate functions called when streams are ready. */
     std::vector<delegate_fn_type> __delegates;
     /** @brief Flag indicating that shutdown has been initiated. */

--- a/network/mqtt/examples/consumer.conf
+++ b/network/mqtt/examples/consumer.conf
@@ -20,7 +20,7 @@
             "max_workers": 0
         }
     },
-    "mqtt": { "address": "127.0.0.1", "port": 1883 },
+    "mqtt": { "address": "127.0.0.1", "port": 1883, "subscribe": true },
     "upnp": { "bind": "239.192.1.2", "port": 7979 },
     "transport": {
         "default": "mqtt",

--- a/network/mqtt/examples/producer.conf
+++ b/network/mqtt/examples/producer.conf
@@ -20,7 +20,7 @@
             "max_workers": 0
         }
     },
-    "mqtt": { "address": "127.0.0.1", "port": 1883 },
+    "mqtt": { "address": "127.0.0.1", "port": 1883, "subscribe": true },
     "upnp": { "bind": "239.192.1.2", "port": 7979 },
     "transport": {
         "default": "mqtt",

--- a/network/mqtt/src/plugin.cpp
+++ b/network/mqtt/src/plugin.cpp
@@ -40,7 +40,7 @@ class plugin_mqtt_execute_after_boot : public zpt::system_event {
 
         for (auto&& [_, __, _service] : _services) {
             if (_service("_id")->string().find("/minions") != std::string::npos) { continue; }
-            auto _topic = zpt::r_replace(_service("_id")->string(), "{}", "*");
+            auto _topic = zpt::r_replace(_service("_id")->string(), "{}", "+");
             _stream->subscribe(_topic);
         }
 
@@ -62,7 +62,7 @@ extern "C" auto _zpt_load_(zpt::plugin& _plugin) -> void {
                                         << _config("port")->integer() << "`",
              zpt::trace);
 
-        if (!_config("subscribe")->is_bool() || _config("subscribe")->boolean()) {
+        if (_config("subscribe")->is_bool() && _config("subscribe")->boolean()) {
             zpt::SYSTEM_EVENTS_RESOLVER() //
               ->add<plugin_mqtt_execute_after_boot>(zpt::system_event_type::FINISHED_BOOT);
         }


### PR DESCRIPTION
- Adds `std::hash<zpt::uuid>`.
- Give that streams can now live longer (websockets), exchanges internal stream
  cache `std::map` by `std::unordered_map`.
- Re-trigger the `zpt::events::call` event whenever the target stream is in use,
  moving from busy wait to async wait.
