### PR TITLE
Callback resolution enhancement with callback unique hash

### DIFF
--- a/common/catalog/include/zapata/catalog/catalog.h
+++ b/common/catalog/include/zapata/catalog/catalog.h
@@ -98,17 +98,18 @@ class catalog {
      * @brief Adds an entry with an explicit provider ID.
      * @param _key Entry key.
      * @param _provider_id Provider identifier.
-     * @param hash Entry hash code.
+     * @param _hash Entry hash code.
      * @param _metadata Entry metadata.
      * @return Reference to this catalog.
      */
-    auto add(K _key, std::string const& _provider_id, std::uint64_t hash, M _metadata) -> catalog&;
+    auto add(K _key, std::string const& _provider_id, std::uint64_t _hash, M _metadata) -> catalog&;
     /**
      * @brief Removes an entry by key.
      * @param _key Entry key to remove.
+     * @param _hash Entry hash code.
      * @return Reference to this catalog.
      */
-    auto remove(K _key) -> catalog&;
+    auto remove(K _key, std::uint64_t _hash) -> catalog&;
     /**
      * @brief Resolves a pattern to matching entries (self provider only).
      * @param _pattern Pattern to match (supports {} placeholders).
@@ -183,10 +184,11 @@ zpt::catalog<K, M>::catalog(std::string const& _catalog_name, std::string const&
 
     sqlite3_exec(static_cast<zpt::storage::sqlite::database*>(&(*_database))->connection().get(), //
                  "CREATE TABLE IF NOT EXISTS catalog ("
-                 "    _id TEXT PRIMARY KEY,"
+                 "    _id TEXT,"
                  "    provider_id TEXT NOT NULL,"
                  "    hash INTEGER NOT NULL,"
                  "    metadata TEXT,"
+                 "    PRIMARY KEY(_id, hash),"
                  "    FOREIGN KEY(provider_id) REFERENCES provider(_id)"
                  ")",
                  nullptr,
@@ -234,19 +236,21 @@ auto zpt::catalog<K, M>::add(K _key,
     std::string _t_key{ _oss.str() };
     _oss.str("");
     _oss << _metadata << std::flush;
-    zpt::json _body{ "provider_id", _provider_id, "hash", _hash, "metadata", _oss.str() };
+    zpt::json _body{ "_id",        _t_key,    "provider_id",
+                     _provider_id, "hash",    static_cast<long long int>(_hash),
+                     "metadata",   _oss.str() };
 
     zlog("Registered " << _t_key, zpt::trace);
     this
       ->__catalog //
-      ->replace(_t_key, _body)
+      ->add(_body)
       ->execute();
 
     return (*this);
 }
 
 template<typename K, typename M>
-auto zpt::catalog<K, M>::remove(K _key) -> catalog& {
+auto zpt::catalog<K, M>::remove(K _key, std::uint64_t _hash) -> catalog& {
     std::ostringstream _oss;
     _oss << _key << std::flush;
     std::string _t_key{ _oss.str() };
@@ -254,7 +258,7 @@ auto zpt::catalog<K, M>::remove(K _key) -> catalog& {
     zlog("Unregistered " << _t_key, zpt::trace);
     this
       ->__catalog //
-      ->remove({ "_id", _t_key })
+      ->remove({ "_id", _t_key, "hash", _hash })
       ->execute();
 
     return (*this);

--- a/common/events/include/zapata/events/resolver.h
+++ b/common/events/include/zapata/events/resolver.h
@@ -86,11 +86,13 @@ class resolver_t {
      * @param _performtive HTTP performative (Get, Post, etc.).
      * @param _id Handler identifier.
      * @param _metadata Optional handler metadata.
+     * @param _callback_hash The callback's unique identifier.
      * @param _callback Resolver callback.
      * @return Reference to this resolver. */
     virtual auto add(zpt::performative _performtive,
                      zpt::json const& _id,
                      zpt::json const& _metadata,
+                     size_t _callback_hash,
                      zpt::events::resolver_callback _callback) -> resolver_t& = 0;
 
     /** @brief Removes an Operation handler (any performative).
@@ -113,8 +115,10 @@ class resolver_t {
     /** @brief Removes a handler by performative and ID.
      * @param _performtive HTTP performative.
      * @param _id Handler identifier.
+     * @param _callback_hash The callback's unique identifier.
      * @return Reference to this resolver. */
-    virtual auto remove(zpt::performative _performtive, zpt::json const& _id) -> resolver_t& = 0;
+    virtual auto remove(zpt::performative _performtive, zpt::json const& _id, size_t _callback_hash)
+      -> resolver_t& = 0;
     /** @brief Returns the total number of registered handlers.
      * @return Handler count. */
     virtual auto count() const -> size_t final;
@@ -185,7 +189,8 @@ template<zpt::events::Operation T>
 auto zpt::events::resolver_t::add(zpt::performative _performative,
                                   zpt::json const& _id,
                                   zpt::json const& _metadata) -> resolver_t& {
-    return this->add(_performative, _id, _metadata, zpt::events::make_callback<T>);
+    return this->add(
+      _performative, _id, _metadata, typeid(T).hash_code(), zpt::events::make_callback<T>);
 }
 
 template<zpt::events::Operation T>
@@ -196,5 +201,5 @@ auto zpt::events::resolver_t::remove(zpt::json const& _id) -> resolver_t& {
 template<zpt::events::Operation T>
 auto zpt::events::resolver_t::remove(zpt::performative _performative, zpt::json const& _id)
   -> resolver_t& {
-    return this->remove(_performative, _id);
+    return this->remove(_performative, _id, typeid(T).hash_code());
 }

--- a/common/events/include/zapata/events/system_events.h
+++ b/common/events/include/zapata/events/system_events.h
@@ -163,11 +163,13 @@ class resolver_t : public zpt::events::resolver_t {
      * @param _performative HTTP performative.
      * @param _id Handler identifier.
      * @param _metadata Handler metadata.
+     * @param _callback_hash The callback's unique identifier.
      * @param _callback Resolver callback.
      * @return Reference to this resolver. */
     auto add(zpt::performative _performative,
              zpt::json const& _id,
              zpt::json const& _metadata,
+             size_t _callback_hash,
              zpt::events::resolver_callback _callback) -> resolver_t& override;
     /** @brief Removes handler for a system event type.
      * @tparam T Operation type to remove.
@@ -182,8 +184,10 @@ class resolver_t : public zpt::events::resolver_t {
     /** @brief Removes callback for a performative/ID combination.
      * @param _performative HTTP performative.
      * @param _id Handler identifier.
+     * @param _callback_hash The callback's unique identifier.
      * @return Reference to this resolver. */
-    auto remove(zpt::performative _performative, zpt::json const& _id) -> resolver_t& override;
+    auto remove(zpt::performative _performative, zpt::json const& _id, size_t _callback_hash)
+      -> resolver_t& override;
     /** @brief Resolves a message to matching system event handlers.
      * @param _received Incoming message to resolve.
      * @param _initializer Event initialization callback.
@@ -218,6 +222,8 @@ class resolver_t : public zpt::events::resolver_t {
      */
     std::map<zpt::system_event_type, std::map<zpt::json, zpt::events::resolver_callback>>
       __callbacks;
+    /** @brief Callback list mutex guard. */
+    mutable zpt::locks::spin_mutex __callbacks_mutex;
 };
 /** @brief Shared pointer type for system events resolver. */
 using resolver = std::shared_ptr<resolver_t>;
@@ -246,6 +252,7 @@ auto zpt::system_events::resolver_t::add(zpt::system_event_type _type) -> resolv
 
 template<zpt::events::Operation T>
 auto zpt::system_events::resolver_t::remove(zpt::system_event_type _type) -> resolver_t& {
+    std::unique_lock _guard{ this->__callbacks_mutex };
     this->__registered_callbacks->fetch_sub(
       this->__callbacks[_type].erase(zpt::system_events::get_id<T>()));
     return (*this);

--- a/common/events/src/system_events.cpp
+++ b/common/events/src/system_events.cpp
@@ -61,7 +61,9 @@ auto zpt::system_events::resolver_t::add(zpt::message,
 auto zpt::system_events::resolver_t::add(zpt::performative,
                                          zpt::json const& _id,
                                          zpt::json const& _type,
+                                         size_t,
                                          zpt::events::resolver_callback _callback) -> resolver_t& {
+    std::unique_lock _guard{ this->__callbacks_mutex };
     this->__callbacks[static_cast<zpt::system_event_type>(_type->integer())].insert(
       std::make_pair(_id, _callback));
     this->__registered_callbacks->fetch_add(1);
@@ -73,8 +75,9 @@ auto zpt::system_events::resolver_t::remove(zpt::message) -> resolver_t& {
     return (*this);
 }
 
-auto zpt::system_events::resolver_t::remove(zpt::performative, zpt::json const& _id)
+auto zpt::system_events::resolver_t::remove(zpt::performative, zpt::json const& _id, size_t)
   -> resolver_t& {
+    std::unique_lock _guard{ this->__callbacks_mutex };
     for (auto& [_, _per_id] : this->__callbacks) {
         this->__registered_callbacks->fetch_sub(_per_id.erase(_id));
     }
@@ -86,6 +89,7 @@ auto zpt::system_events::resolver_t::resolve(zpt::message _received,
   -> std::list<zpt::event> {
     std::list<zpt::event> _return;
 
+    std::shared_lock _guard{ this->__callbacks_mutex };
     auto _type = _received->resource()->integer();
     auto _per_id = this->__callbacks.find(static_cast<zpt::system_event_type>(_type));
     if (_per_id != this->__callbacks.end()) {

--- a/engines/rest/include/zapata/rest/rest.h
+++ b/engines/rest/include/zapata/rest/rest.h
@@ -107,12 +107,14 @@ class resolver_t : public zpt::events::resolver_t {
      * @param _performative HTTP performative (e.g., zpt::Get, zpt::Post).
      * @param _id URI pattern or handler identifier.
      * @param _metadata Optional handler metadata.
+     * @param _callback_hash The callback's unique identifier.
      * @param _callback Resolver callback to invoke on match.
      * @return Reference to this resolver.
      */
     auto add(zpt::performative _performative,
              zpt::json const& _id,
              zpt::json const& _metadata,
+             size_t _callback_hash,
              zpt::events::resolver_callback _callback) -> resolver_t& override;
     /**
      * @brief Removes the callback registered for a sent message.
@@ -124,9 +126,11 @@ class resolver_t : public zpt::events::resolver_t {
      * @brief Removes callback for a performative/URI combination.
      * @param _performative The HTTP performative (GET, POST, etc.).
      * @param _id The URI pattern or identifier.
+     * @param _callback_hash The callback's unique identifier.
      * @return Reference to this resolver instance.
      */
-    auto remove(zpt::performative _performative, zpt::json const& _id) -> resolver_t& override;
+    auto remove(zpt::performative _performative, zpt::json const& _id, size_t _callback_hash)
+      -> resolver_t& override;
     /**
      * @brief Resolves an incoming request to matching REST handlers.
      * @param _received Incoming message.
@@ -172,7 +176,9 @@ class resolver_t : public zpt::events::resolver_t {
     /** @brief Catalog mapping URI patterns to callback indices. */
     zpt::catalog<std::string, zpt::json>::ptr __catalog{ nullptr };
     /** @brief Vector of registered REST callback handlers. */
-    std::vector<zpt::events::resolver_callback> __callbacks;
+    std::map<size_t, zpt::events::resolver_callback> __callbacks;
+    /** @brief Callback list mutex guard. */
+    mutable zpt::locks::spin_mutex __callbacks_mutex;
     /** @brief Store for pending request/response callbacks. */
     mutable zpt::rest::pending_messages __pending_requests;
     /** @brief Configuration passed to the resolver at construction. */

--- a/engines/rest/src/rest.cpp
+++ b/engines/rest/src/rest.cpp
@@ -42,18 +42,21 @@ auto zpt::rest::resolver_t::add(zpt::message _sent,
 auto zpt::rest::resolver_t::add(zpt::performative _performative,
                                 zpt::json const& _id,
                                 zpt::json const& _metadata,
+                                size_t _callback_hash,
                                 zpt::events::resolver_callback _callback)
   -> zpt::rest::resolver_t& {
     auto _path = _id->string();
-    auto hash_code = this->__callbacks.size();
-    this->__callbacks.push_back(_callback);
+    {
+        std::unique_lock _guard{ this->__callbacks_mutex };
+        this->__callbacks.insert(std::make_pair(_callback_hash, _callback));
+    }
     this->__registered_callbacks->fetch_add(1);
     auto _to_add =
       std::format("/{}{}",
                   (_performative == zpt::Performative_end ? std::string{ "{}" }
                                                           : zpt::ontology::to_str(_performative)),
                   _path);
-    this->__catalog->add(_to_add, hash_code, _metadata);
+    this->__catalog->add(_to_add, _callback_hash, _metadata);
     return (*this);
 }
 
@@ -78,8 +81,9 @@ auto zpt::rest::resolver_t::remove(zpt::message _sent) -> zpt::rest::resolver_t&
     return (*this);
 }
 
-auto zpt::rest::resolver_t::remove(zpt::performative _performative, zpt::json const& _id)
-  -> zpt::rest::resolver_t& {
+auto zpt::rest::resolver_t::remove(zpt::performative _performative,
+                                   zpt::json const& _id,
+                                   size_t _callback_hash) -> zpt::rest::resolver_t& {
     auto _path = _id->string();
     auto _to_search =
       std::format("/{}{}",
@@ -87,15 +91,14 @@ auto zpt::rest::resolver_t::remove(zpt::performative _performative, zpt::json co
                                                           : zpt::ontology::to_str(_performative)),
                   _path);
     for (auto&& [_, __, _record] : this->__catalog->search(_to_search)) {
-        auto _hash_code = _record("hash")->integer();
-        expect(static_cast<unsigned>(_hash_code) < this->__callbacks.size(),
-               "Couldn't find callback for [" << _hash_code << "](" << _path << ")");
-        if (this->__callbacks[_hash_code] != nullptr) {
-            this->__callbacks[_hash_code] = nullptr;
-            this->__registered_callbacks->fetch_sub(1);
-        }
+        auto _hash_code = static_cast<unsigned long long int>(_record("hash")->integer());
+        if (_hash_code != _callback_hash) { continue; }
+
+        this->__catalog->remove(_to_search, _hash_code);
+
+        std::unique_lock _guard{ this->__callbacks_mutex };
+        this->__registered_callbacks->fetch_sub(this->__callbacks.erase(_callback_hash));
     }
-    this->__catalog->remove(_to_search);
     return (*this);
 }
 
@@ -110,10 +113,13 @@ auto zpt::rest::resolver_t::resolve(zpt::message _received,
                                       _received->resource()->string());
         for (auto&& [_, __, _record] : this->__catalog->resolve(_to_search)) {
             auto _hash_code = _record("hash")->integer();
-            expect(static_cast<unsigned>(_hash_code) < this->__callbacks.size(),
+
+            std::shared_lock _guard{ this->__callbacks_mutex };
+            auto _found = this->__callbacks.find(_hash_code);
+            expect(_found != this->__callbacks.end(),
                    "Couldn't find callback for [" << _hash_code << "]("
                                                   << _received->resource()->string() << ")");
-            _return.push_back(this->__callbacks[_hash_code](_received, nullptr, _initializer));
+            _return.push_back(_found->second(_received, nullptr, _initializer));
         }
     }
     else {


### PR DESCRIPTION
- Resolvers take callback unique hash in order to be able to resolve multiple callback for the same service identifier.
- Callback hashes are automatically produced by `resolver_t` parent class, by using `type_info::hash_code` of the callback class.