### PR TITLE
Stopping threads before unloading plugins

### DIFF
--- a/bridges/lua/CMakeLists.txt
+++ b/bridges/lua/CMakeLists.txt
@@ -55,12 +55,13 @@ set_target_properties(zapata-bridge-lua
 add_library(zapata-bridge-lua-plugin SHARED)
 add_dependencies(zapata-bridge-lua-plugin
   zapata-base
-  zapata-parser-json
-  zapata-events
-  zapata-engine-startup
   zapata-bridge-base
   zapata-bridge-lua
+  zapata-engine-startup
   zapata-engine-rest
+  zapata-events
+  zapata-parser-json
+  zapata-runtime
 )
 target_sources(zapata-bridge-lua-plugin
   PRIVATE
@@ -70,16 +71,17 @@ target_sources(zapata-bridge-lua-plugin
 target_include_directories(zapata-bridge-lua-plugin
   PRIVATE
     zapata-base
-    zapata-common-catalog
-    zapata-globals
-    zapata-events
-    zapata-lockfree
-    zapata-parser-json
-    zapata-engine-startup
     zapata-bridge-base
     zapata-bridge-lua
+    zapata-common-catalog
     zapata-engine-rest
+    zapata-engine-startup
     zapata-engine-transport
+    zapata-events
+    zapata-globals
+    zapata-lockfree
+    zapata-parser-json
+    zapata-runtime
     ${BRIDGE_LUA_INCLUDE_DIR}
   INTERFACE
     ${BRIDGE_LUA_INCLUDE_DIR}
@@ -87,18 +89,19 @@ target_include_directories(zapata-bridge-lua-plugin
 target_link_libraries(zapata-bridge-lua-plugin
   PUBLIC
     zapata-base
-    zapata-common-catalog
-    zapata-globals
-    zapata-events
-    zapata-lockfree
-    zapata-parser-json
-    zapata-engine-startup
     zapata-bridge-base
     zapata-bridge-lua
+    zapata-common-catalog
     zapata-engine-rest
+    zapata-engine-startup
     zapata-engine-transport
-    ${SQLite3_LIBRARIES}
+    zapata-events
+    zapata-globals
+    zapata-lockfree
+    zapata-parser-json
+    zapata-runtime
     zapata-storage-sqlite
+    ${SQLite3_LIBRARIES}
     ${LUA_LIBRARIES}
 )
 set_target_properties(zapata-bridge-lua-plugin

--- a/bridges/lua/src/bindings.cpp
+++ b/bridges/lua/src/bindings.cpp
@@ -1,5 +1,6 @@
 #include <zapata/lua/bindings.h>
 #include <zapata/rest.h>
+#include <zapata/runtime.h>
 #include <zapata/transport/engine.h>
 
 namespace {
@@ -135,7 +136,7 @@ auto zpt::lua::bindings::sleep(lua_State* _state) -> int {
 
 auto zpt::lua::bindings::is_in_shutdown(lua_State* _state) -> int {
     auto& _bridge = zpt::LUA_BRIDGE().thread_instance();
-    _bridge.to_object(zpt::STREAM_POLLING()->is_in_shutdown(), _state);
+    _bridge.to_object(zpt::runtime::is_in_shutdown(), _state);
     return 1;
 }
 

--- a/bridges/prolog/CMakeLists.txt
+++ b/bridges/prolog/CMakeLists.txt
@@ -54,11 +54,12 @@ set_target_properties(zapata-bridge-prolog
 add_library(zapata-bridge-prolog-plugin SHARED)
 add_dependencies(zapata-bridge-prolog-plugin
   zapata-base
-  zapata-parser-json
-  zapata-events
-  zapata-engine-startup
   zapata-bridge-base
   zapata-bridge-prolog
+  zapata-engine-startup
+  zapata-events
+  zapata-parser-json
+  zapata-runtime
 )
 target_sources(zapata-bridge-prolog-plugin
   PRIVATE
@@ -67,13 +68,14 @@ target_sources(zapata-bridge-prolog-plugin
 target_include_directories(zapata-bridge-prolog-plugin
   PRIVATE
     zapata-base
-    zapata-globals
-    zapata-events
-    zapata-lockfree
-    zapata-parser-json
-    zapata-engine-startup
     zapata-bridge-base
     zapata-bridge-prolog
+    zapata-engine-startup
+    zapata-events
+    zapata-globals
+    zapata-lockfree
+    zapata-parser-json
+    zapata-runtime
     ${BRIDGE_PROLOG_INCLUDE_DIR}
   INTERFACE
     ${BRIDGE_PROLOG_INCLUDE_DIR}
@@ -81,12 +83,13 @@ target_include_directories(zapata-bridge-prolog-plugin
 target_link_libraries(zapata-bridge-prolog-plugin
   PUBLIC
     zapata-base
-    zapata-parser-json
-    zapata-events
-    zapata-lockfree
-    zapata-engine-startup
     zapata-bridge-base
     zapata-bridge-prolog
+    zapata-events
+    zapata-engine-startup
+    zapata-lockfree
+    zapata-parser-json
+    zapata-runtime
     swipl::libswipl
 )
 set_target_properties(zapata-bridge-prolog-plugin
@@ -105,6 +108,7 @@ add_dependencies(zapata_bridge_prolog_bindings
   zapata-engine-startup
   zapata-bridge-base
   zapata-bridge-prolog
+  zapata-runtime
 )
 target_sources(zapata_bridge_prolog_bindings
   PRIVATE
@@ -123,6 +127,7 @@ target_include_directories(zapata_bridge_prolog_bindings
     zapata-bridge-prolog
     zapata-engine-rest
     zapata-engine-transport
+    zapata-runtime
     ${BRIDGE_PROLOG_INCLUDE_DIR}
   INTERFACE
     ${BRIDGE_PROLOG_INCLUDE_DIR}
@@ -140,6 +145,7 @@ target_link_libraries(zapata_bridge_prolog_bindings
     zapata-engine-rest
     zapata-engine-transport
     swipl::libswipl
+    zapata-runtime
     ${SQLite3_LIBRARIES}
     zapata-storage-sqlite
 )

--- a/bridges/prolog/src/bindings.cpp
+++ b/bridges/prolog/src/bindings.cpp
@@ -11,6 +11,7 @@
 
 #include <zapata/prolog/bindings.h>
 #include <zapata/rest.h>
+#include <zapata/runtime.h>
 #include <zapata/transport/engine.h>
 
 namespace {
@@ -243,7 +244,7 @@ static auto get_value_for_key(term_t _to_search_pl /*+*/,
  * @return bool True if the system is in shutdown.
  */
 static auto is_in_shutdown(term_t _result_pl /*?*/) -> foreign_t {
-    auto _result = zpt::prolog::to_object(zpt::STREAM_POLLING()->is_in_shutdown());
+    auto _result = zpt::prolog::to_object(zpt::runtime::is_in_shutdown());
     return PL_unify_term(_result_pl, PL_TERM, *_result);
 }
 }

--- a/common/catalog/include/zapata/catalog/catalog.h
+++ b/common/catalog/include/zapata/catalog/catalog.h
@@ -188,7 +188,7 @@ zpt::catalog<K, M>::catalog(std::string const& _catalog_name, std::string const&
                  "    provider_id TEXT NOT NULL,"
                  "    hash INTEGER NOT NULL,"
                  "    metadata TEXT,"
-                 "    PRIMARY KEY(_id, hash),"
+                 "    PRIMARY KEY(_id, provider_id, hash),"
                  "    FOREIGN KEY(provider_id) REFERENCES provider(_id)"
                  ")",
                  nullptr,
@@ -240,7 +240,7 @@ auto zpt::catalog<K, M>::add(K _key,
                      _provider_id, "hash",    static_cast<long long int>(_hash),
                      "metadata",   _oss.str() };
 
-    zlog("Registered " << _t_key, zpt::trace);
+    if (static_cast<long long int>(_hash) != -1) { zlog("Registered " << _t_key, zpt::trace); }
     this
       ->__catalog //
       ->add(_body)
@@ -255,7 +255,7 @@ auto zpt::catalog<K, M>::remove(K _key, std::uint64_t _hash) -> catalog& {
     _oss << _key << std::flush;
     std::string _t_key{ _oss.str() };
 
-    zlog("Unregistered " << _t_key, zpt::trace);
+    if (static_cast<long long int>(_hash) != -1) { zlog("Unregistered " << _t_key, zpt::trace); }
     this
       ->__catalog //
       ->remove({ "_id", _t_key, "hash", _hash })

--- a/common/events/src/dispatcher.cpp
+++ b/common/events/src/dispatcher.cpp
@@ -53,9 +53,13 @@ auto zpt::events::dispatcher::start_consumers(long _n_consumers) -> dispatcher& 
 }
 
 auto zpt::events::dispatcher::stop_consumers() -> dispatcher& {
-    expect(!this->__shutdown->load(),
-           "`stop_consunmers()` already been called from another execution path");
-    this->__shutdown->store(true);
+    while (this->__queue.size() != 0) {
+        std::this_thread::sleep_for(std::chrono::duration<int, std::milli>{ 100 });
+    }
+
+    if (this->__shutdown->exchange(true)) { return (*this); }
+    this->__queue.shutdown();
+
     while (this->__running_consumers->load(std::memory_order_relaxed) != 0) {
         std::this_thread::sleep_for(std::chrono::duration<int, std::milli>{ 100 });
     }
@@ -65,6 +69,7 @@ auto zpt::events::dispatcher::stop_consumers() -> dispatcher& {
 }
 
 auto zpt::events::dispatcher::trigger(zpt::event _event) -> dispatcher& {
+    if (this->__shutdown->load()) { return (*this); }
     this->__queue.push(std::move(_event));
     return (*this);
 }

--- a/common/lockfree/include/zapata/lockfree/queue.h
+++ b/common/lockfree/include/zapata/lockfree/queue.h
@@ -160,6 +160,11 @@ class queue {
      * @return Current number of elements in the queue.
      */
     auto size() const -> size_t;
+    /**
+     * @brief Instructs all threads spinning in `push` or `pop` to exit.
+     * @return Reference to this queue.
+     */
+    auto shutdown() -> zpt::lf::queue<T>&;
 
     /**
      * @brief Returns a debug string representation of the queue.
@@ -212,6 +217,8 @@ class queue {
     zpt::padded_atomic<std::uint64_t> __tail{ 0 };
     /** @brief Approximate element count, updated independently of the slot CAS. */
     zpt::padded_atomic<std::uint64_t> __size{ 0 };
+    /** @brief Stop all spinning and exit. */
+    zpt::padded_atomic<bool> __shutdown{ false };
     /** @brief Maximum number of elements the queue can hold (power of two). */
     size_t __capacity{ 0 };
     /** @brief Bit mask for index wrapping: `__capacity - 1`. */
@@ -239,6 +246,7 @@ auto zpt::lf::queue<T>::push(T _value) -> zpt::lf::queue<T>& {
 
 template<typename T>
 auto zpt::lf::queue<T>::push(ptr&& _value) -> zpt::lf::queue<T>& {
+    zpt::this_thread::timer<float> _timer{ 0.01f };
     for (;;) {
         auto _head = this->__head->load(std::memory_order_relaxed);
 
@@ -251,8 +259,12 @@ auto zpt::lf::queue<T>::push(ptr&& _value) -> zpt::lf::queue<T>& {
             // Spin-wait until the slot is free (sequence == slot_index).
             while (this->__slots[_slot_idx].sequence->load(std::memory_order_acquire) !=
                    _slot_idx) {
-                std::this_thread::yield();
+                _timer.sleep_for(0.1f);
+                if (this->__shutdown->load()) {
+                    throw zpt::NoMoreElementsException("Shutting down");
+                }
             }
+            _timer.reset();
 
             // Write the value and release the slot to consumers.
             this->__slots[_slot_idx].value = std::move(_value);
@@ -271,6 +283,7 @@ auto zpt::lf::queue<T>::push(ptr&& _value) -> zpt::lf::queue<T>& {
 
 template<typename T>
 auto zpt::lf::queue<T>::pop() -> ptr {
+    zpt::this_thread::timer<float> _timer{ 0.01f };
     for (;;) {
         if (this->__tail->load() == this->__head->load()) {
             throw zpt::NoMoreElementsException("No elements in the queue");
@@ -287,8 +300,12 @@ auto zpt::lf::queue<T>::pop() -> ptr {
             // Spin-wait until the slot is full (sequence == slot_index + capacity).
             while (this->__slots[_slot_idx].sequence->load(std::memory_order_acquire) !=
                    (_slot_idx + this->__capacity)) {
-                std::this_thread::yield();
+                _timer.sleep_for(0.1f);
+                if (this->__shutdown->load()) {
+                    throw zpt::NoMoreElementsException("Shutting down");
+                }
             }
+            _timer.reset();
 
             // Read the value and release the slot to producers.
             ptr _to_return;
@@ -313,6 +330,12 @@ auto zpt::lf::queue<T>::capacity() const -> size_t {
 template<typename T>
 auto zpt::lf::queue<T>::size() const -> size_t {
     return this->__size->load(std::memory_order_relaxed);
+}
+
+template<typename T>
+auto zpt::lf::queue<T>::shutdown() -> zpt::lf::queue<T>& {
+    this->__shutdown->store(true);
+    return (*this);
 }
 
 template<typename T>

--- a/common/testing/src/plugin.cpp
+++ b/common/testing/src/plugin.cpp
@@ -38,7 +38,7 @@ class plugin_testing_execute_after_boot : public zpt::system_event {
     using zpt::system_event::system_event;
     ~plugin_testing_execute_after_boot() = default;
 
-    auto operator()(zpt::events::dispatcher::ptr) -> zpt::events::state override {
+    auto operator()(zpt::events::dispatcher::ptr _dispatcher) -> zpt::events::state override {
         auto& _bridge = zpt::LUA_BRIDGE().thread_instance();
         auto _config = zpt::GLOBAL_CONFIG();
         auto _dummy_args = zpt::json::array();
@@ -53,6 +53,9 @@ class plugin_testing_execute_after_boot : public zpt::system_event {
             catch (std::exception const& _e) {
                 zlog(_target->string() << ": fail - " << _e.what(), zpt::warning);
                 _failed << _target;
+            }
+            if (_dispatcher->is_in_shutdown()) {
+                break;
             }
         }
 

--- a/engines/rest/src/services.cpp
+++ b/engines/rest/src/services.cpp
@@ -39,7 +39,10 @@ auto zpt::rest::minion_boot::operator()(zpt::events::dispatcher::ptr _dispatcher
                                _peer_scheme,
                                _peer("domain")->string(),
                                _peer("port")->integer()))
-              .body() = { "provider", zpt::IDENTITY(), "services", zpt::REST_RESOLVER()->list() };
+              .body() = { "provider",
+                          zpt::IDENTITY(),
+                          "services",
+                          zpt::REST_RESOLVER()->list(zpt::IDENTITY()("_id")->string()) };
 
             zpt::make_call<zpt::rest::services_list>(zpt::REST_RESOLVER(), _hello);
 #ifndef PROPAGATE_EXCEPTION

--- a/engines/runtime/include/zapata/runtime.h
+++ b/engines/runtime/include/zapata/runtime.h
@@ -15,5 +15,9 @@ auto initialize(int _argc, char** _argv) -> void;
  * @return void
  */
 auto shutdown() -> void;
+/** @brief Whether or not the system is in shutdown.
+ * @return True if the system is in shutdown;
+ */
+auto is_in_shutdown() -> bool;
 } // namespace runtime
 } // namespace zpt

--- a/engines/runtime/src/runtime.cpp
+++ b/engines/runtime/src/runtime.cpp
@@ -128,17 +128,17 @@ auto zpt::runtime::initialize(int _argc, char** _argv) -> void {
     zpt::STREAM_POLLING() //
       ->shutdown();
     zlog("Unloaded stream polling service", zpt::info);
+    zpt::DISPATCHER() //
+      ->trigger<zpt::system_event>(zpt::system_event_type::EXITING);
+    zpt::DISPATCHER() //
+      ->stop_consumers();
+    zlog("Stopped global event dispatcher", zpt::info);
     zpt::BOOT() //
       .unload();
     zlog("Unloaded all plugins", zpt::notice);
     zpt::TRANSPORT_LAYER() //
       .clear();
     zlog("Unloaded transport layer", zpt::info);
-    zpt::DISPATCHER() //
-      ->trigger<zpt::system_event>(zpt::system_event_type::EXITING);
-    zpt::DISPATCHER() //
-      ->stop_consumers();
-    zlog("Stopped global event dispatcher", zpt::info);
     zlog("Server PID " << zpt::log_pid << " stopped, exiting now", zpt::notice);
     if (_config("log")("target")->ok()) { delete zpt::log_fd; }
 
@@ -149,6 +149,8 @@ auto zpt::runtime::initialize(int _argc, char** _argv) -> void {
 }
 
 auto zpt::runtime::shutdown() -> void { zpt::STREAM_POLLING()->shutdown(); }
+
+auto zpt::runtime::is_in_shutdown() -> bool { return zpt::STREAM_POLLING()->is_in_shutdown(); }
 
 namespace {
 auto deallocate(int) -> void { zpt::STREAM_POLLING()->shutdown(); }

--- a/engines/startup/src/configuration.cpp
+++ b/engines/startup/src/configuration.cpp
@@ -77,8 +77,7 @@ auto zpt::startup::configuration::load_defaults() -> zpt::json {
                  { "name": "builtin:tcp" },
                  { "name": "builtin:upnp" },
                  { "name": "builtin:ws" },
-                 { "name": "builtin:rest" },
-                 { "name": "builtin:lua" }
+                 { "name": "builtin:rest" }
              ],
              "resources": {
                  "limits": {

--- a/engines/transport/src/plugin.cpp
+++ b/engines/transport/src/plugin.cpp
@@ -25,6 +25,21 @@
 #include <zapata/transport.h>
 #include <zapata/transport/engine.h>
 
+namespace {
+class transport_engine_stop_threads : public zpt::system_event {
+  public:
+    using zpt::system_event::system_event;
+    ~transport_engine_stop_threads() = default;
+
+    auto operator()(zpt::events::dispatcher::ptr) -> zpt::events::state override {
+        zpt::SYSTEM_EVENTS_RESOLVER()->remove<::transport_engine_stop_threads>(
+          zpt::system_event_type::EXITING);
+        zpt::TRANSPORT_ENGINE()->shutdown();
+        return zpt::events::finish;
+    }
+};
+} // namespace
+
 /** @brief Plugin entry point: initializes the global transport engine.
  * @param _plugin Plugin instance.
  * @return void. */
@@ -36,6 +51,9 @@ extern "C" auto _zpt_load_(zpt::plugin& _plugin) -> void {
                  : 1)
            << " threads)",
          zpt::info);
+
+    zpt::SYSTEM_EVENTS_RESOLVER()->add<::transport_engine_stop_threads>(
+      zpt::system_event_type::EXITING);
 }
 
 /** @brief Plugin unload entry point: shuts down the transport engine.
@@ -43,5 +61,4 @@ extern "C" auto _zpt_load_(zpt::plugin& _plugin) -> void {
  * @return void. */
 extern "C" auto _zpt_unload_(zpt::plugin&) -> void {
     zlog("Stopped multi-transport engine", zpt::info);
-    zpt::TRANSPORT_ENGINE()->shutdown();
 }

--- a/network/amqp/CMakeLists.txt
+++ b/network/amqp/CMakeLists.txt
@@ -90,6 +90,7 @@ add_dependencies(zapata-net-amqp-plugin
   zapata-net-transport
   zapata-parser-json
   zapata-parser-uri
+  zapata-runtime
 )
 target_sources(zapata-net-amqp-plugin
   PRIVATE
@@ -110,6 +111,7 @@ target_include_directories(zapata-net-amqp-plugin
     zapata-net-transport
     zapata-parser-json
     zapata-parser-uri
+    zapata-runtime
     zapata-storage-sqlite
     ${SQLite3_LIBRARIES}
     ${NETWORK_TCP_INCLUDE_DIR}
@@ -130,6 +132,7 @@ target_link_libraries(zapata-net-amqp-plugin
     zapata-net-transport
     zapata-parser-json
     zapata-parser-uri
+    zapata-runtime
     zapata-storage-sqlite
     ${SQLite3_LIBRARIES}
     Proton::qpid-proton

--- a/network/amqp/src/plugin.cpp
+++ b/network/amqp/src/plugin.cpp
@@ -34,6 +34,7 @@
 #include <zapata/net/transport/amqp.h>
 #include <zapata/net/transport/self.h>
 #include <zapata/startup.h>
+#include <zapata/runtime.h>
 #include <zapata/transport.h>
 
 /** @brief System event that subscribes to AMQP topics at boot time.
@@ -97,7 +98,7 @@ extern "C" auto _zpt_load_(zpt::plugin& _plugin) -> void {
                                                         << _config("port")->integer(),
                  zpt::info);
 
-            while (!zpt::STREAM_POLLING()->is_in_shutdown()) {
+            while (!zpt::runtime::is_in_shutdown()) {
                 try {
                     if (!_stream->is_connected()) { _stream->connect(); }
                     _stream->loop_misc();

--- a/network/mqtt/CMakeLists.txt
+++ b/network/mqtt/CMakeLists.txt
@@ -106,6 +106,7 @@ add_dependencies(zapata-net-mqtt-plugin
   zapata-net-transport
   zapata-parser-json
   zapata-parser-uri
+  zapata-runtime
 )
 target_sources(zapata-net-mqtt-plugin
   PRIVATE
@@ -126,6 +127,7 @@ target_include_directories(zapata-net-mqtt-plugin
     zapata-net-transport
     zapata-parser-json
     zapata-parser-uri
+    zapata-runtime
     zapata-storage-sqlite
     ${SQLite3_LIBRARIES}
     ${MOSQUITTO_INCLUDE_DIR}
@@ -147,6 +149,7 @@ target_link_libraries(zapata-net-mqtt-plugin
     zapata-net-transport
     zapata-parser-json
     zapata-parser-uri
+    zapata-runtime
     zapata-storage-sqlite
     ${SQLite3_LIBRARIES}
     ${MOSQUITTO_LIBRARY}

--- a/network/mqtt/src/plugin.cpp
+++ b/network/mqtt/src/plugin.cpp
@@ -25,6 +25,7 @@
 #include <zapata/net/socket.h>
 #include <zapata/net/transport/mqtt.h>
 #include <zapata/net/transport/self.h>
+#include <zapata/runtime.h>
 #include <zapata/startup.h>
 #include <zapata/transport.h>
 
@@ -75,7 +76,7 @@ extern "C" auto _zpt_load_(zpt::plugin& _plugin) -> void {
                                                         << _config("port")->integer(),
                  zpt::info);
 
-            while (!zpt::STREAM_POLLING()->is_in_shutdown()) {
+            while (!zpt::runtime::is_in_shutdown()) {
                 try {
                     if (!_stream->is_connected()) { _stream->connect(); }
                     _stream->loop_misc();


### PR DESCRIPTION
- Threads in dispatchers are stopped just after the stream-polling
  infra-structure and before plugin unloading.
- Queues are depleted before threads are stopped.