### PR TITLE
Transform messages from one protocol to another

### DIFF
--- a/common/base/examples/base.cpp
+++ b/common/base/examples/base.cpp
@@ -96,10 +96,11 @@ auto test_uuid() -> void {
     expect(_uuid == _parsed, "UUIDs are the same");
 
     auto _22_byte = _uuid.to_base64_string();
-    _parsed.from_base64_string(_22_byte);
+    zpt::uuid _parsed2;
+    _parsed2.from_base64_string(_22_byte);
     std::cout << _22_byte << std::endl;
-    std::cout << _uuid << " == " << _parsed << std::endl;
-    expect(_uuid == _parsed, "UUIDs are the same");
+    std::cout << _uuid << " == " << _parsed2 << std::endl;
+    expect(_uuid == _parsed2, "UUIDs are the same");
 }
 
 auto main(int, char*[]) -> int {

--- a/common/ontology/include/zapata/ontology/message.h
+++ b/common/ontology/include/zapata/ontology/message.h
@@ -57,6 +57,10 @@ namespace zpt {
  */
 class basic_message {
   public:
+    /** @brief Retrieves a copy of this message of the given template type.
+     * @return Shared pointer to cloned message. */
+    template<typename T>
+    auto copy() const -> std::shared_ptr<basic_message>;
     /** @brief Retrieves a clone of this message.
      * @return Shared pointer to cloned message. */
     virtual auto clone() const -> std::shared_ptr<basic_message> = 0;
@@ -379,10 +383,27 @@ template<typename T>
 auto message_cast(zpt::message _rhs) -> T& {
     return static_cast<T&>(*_rhs);
 }
+auto uri_to_string(zpt::json const& _uri) -> std::string;
 } // namespace zpt
 
 auto operator<<(std::ostream& _out, zpt::message _in) -> std::ostream&;
 auto operator>>(std::istream& _in, zpt::message _out) -> std::istream&;
+
+template<typename T>
+auto zpt::basic_message::copy() const -> std::shared_ptr<basic_message> {
+    auto _copy = zpt::make_message<T>();
+
+    _copy->headers() = this->headers()->clone();
+    _copy->body() = this->body()->clone();
+    _copy //
+      ->performative(this->performative())
+      .uri(zpt::uri_to_string(this->uri()))
+      .version(this->version());
+
+    if (this->performative() == zpt::Reply) { _copy->status(this->status()); }
+
+    return _copy;
+}
 
 template<typename T, typename... Args>
 auto zpt::make_message(Args... _args) -> zpt::message {

--- a/common/ontology/src/message.cpp
+++ b/common/ontology/src/message.cpp
@@ -180,6 +180,10 @@ auto zpt::json_message::empty() const -> bool {
     return !this->__underlying->ok() || this->__underlying->stringify().length() == 0;
 }
 
+auto zpt::uri_to_string(zpt::json const& _uri) -> std::string {
+    return zpt::uri::to_string(_uri);
+}
+
 auto operator<<(std::ostream& _out, zpt::message _in) -> std::ostream& {
     _in->to_stream(_out);
     return _out;

--- a/engines/runtime/src/runtime.cpp
+++ b/engines/runtime/src/runtime.cpp
@@ -125,14 +125,14 @@ auto zpt::runtime::initialize(int _argc, char** _argv) -> void {
 
     zpt::DISPATCHER() //
       ->trigger<zpt::system_event>(zpt::system_event_type::SHUTTING_DOWN);
-    zpt::STREAM_POLLING() //
-      ->shutdown();
-    zlog("Unloaded stream polling service", zpt::info);
     zpt::DISPATCHER() //
       ->trigger<zpt::system_event>(zpt::system_event_type::EXITING);
     zpt::DISPATCHER() //
       ->stop_consumers();
     zlog("Stopped global event dispatcher", zpt::info);
+    zpt::STREAM_POLLING() //
+      ->close();
+    zlog("Unloaded stream polling service", zpt::info);
     zpt::BOOT() //
       .unload();
     zlog("Unloaded all plugins", zpt::notice);

--- a/engines/transport/src/engine.cpp
+++ b/engines/transport/src/engine.cpp
@@ -144,7 +144,6 @@ auto zpt::events::receive::check_upgrade(zpt::message _received) -> bool {
                                zpt::base64::r_encode(zpt::crypto::sha1_bytes(_key)));
             }
 
-            _transport->send(this->__stream, _reply);
             auto _metadata = _received->clone();
             _metadata //
               ->headers()
@@ -153,6 +152,8 @@ auto zpt::events::receive::check_upgrade(zpt::message _received) -> bool {
               .pop("Upgrade");
             this->__stream->metadata(std::make_any<zpt::message>(_metadata));
             this->__polling->upgrade(this->__stream, _value);
+
+            _transport->send(this->__stream, _reply);
             return true;
         }
     }
@@ -165,7 +166,7 @@ auto zpt::events::receive::operator()(zpt::events::dispatcher::ptr _dispatcher)
                         .get(this->__stream->transport());
     try {
         auto _received = _transport->receive(this->__stream);
-        if (!_received->empty() && !this->__polling->is_in_shutdown() &&
+        if (_received != nullptr && !_received->empty() && !this->__polling->is_in_shutdown() &&
             !_dispatcher->is_in_shutdown()) {
 
             if (this->check_upgrade(_received)) {

--- a/io/stream/src/streams.cpp
+++ b/io/stream/src/streams.cpp
@@ -299,7 +299,6 @@ auto zpt::polling::poll() -> zpt::polling& {
         }
 
     } while (!this->__shutdown.load());
-    this->close();
     return (*this);
 }
 

--- a/network/amqp/include/zapata/net/transport/amqp.h
+++ b/network/amqp/include/zapata/net/transport/amqp.h
@@ -87,6 +87,10 @@ class amqp : public zpt::basic_transport {
      * @param _to_publish Message to publish with routing keys extracted from URI.
      * @return void */
     auto publish(zpt::message _to_publish) const -> void override;
+    /** @brief Creates a copy of the given message with the transport's protocol and format.
+     * @param _to_copy The message to copy.
+     * @return The copied message. */
+    auto copy(zpt::message const& _to_copy) const -> zpt::message override;
 };
 } // namespace transport
 } // namespace net

--- a/network/amqp/src/amqp.cpp
+++ b/network/amqp/src/amqp.cpp
@@ -73,6 +73,10 @@ auto zpt::net::transport::amqp::publish(zpt::message _to_publish) const -> void 
     _server->publish(_to_publish);
 }
 
+auto zpt::net::transport::amqp::copy(zpt::message const& _to_copy) const -> zpt::message {
+    return _to_copy->copy<zpt::json_message>();
+}
+
 auto zpt::AMQP_STREAM(zpt::json _config) -> zpt::amqp_stream::ptr {
     static auto _global = zpt::allocate_shared<zpt::amqp_stream>(_config);
     return _global;

--- a/network/http/include/zapata/net/transport/http.h
+++ b/network/http/include/zapata/net/transport/http.h
@@ -86,6 +86,10 @@ class http : public zpt::basic_transport {
      * @param _stream Input stream containing the serialized HTTP reply.
      * @return Parsed reply message. */
     auto process_incoming_reply(zpt::stream _stream) const -> zpt::message override;
+    /** @brief Creates a copy of the given message with the transport's protocol and format.
+     * @param _to_copy The message to copy.
+     * @return The copied message. */
+    auto copy(zpt::message const& _to_copy) const -> zpt::message override;
 };
 } // namespace transport
 } // namespace net

--- a/network/http/src/http.cpp
+++ b/network/http/src/http.cpp
@@ -72,6 +72,11 @@ auto zpt::net::transport::http::process_incoming_reply(zpt::stream _stream) cons
     return _reply;
 }
 
+auto zpt::net::transport::http::copy(zpt::message const& _to_copy) const -> zpt::message {
+    if (_to_copy->performative() == zpt::Reply) { return _to_copy->copy<zpt::http::basic_reply>(); }
+    else { return _to_copy->copy<zpt::http::basic_request>(); }
+}
+
 auto zpt::HTTP_SERVER_SOCKET(std::string const& _address, std::uint16_t _port)
   -> zpt::serversocketstream& {
     static zpt::serversocketstream _global{ "http", _address, _port };

--- a/network/local/include/zapata/net/transport/local.h
+++ b/network/local/include/zapata/net/transport/local.h
@@ -78,6 +78,10 @@ class unix_socket : public zpt::basic_transport {
      * @param _stream Input stream containing the serialized reply.
      * @return Parsed reply message. */
     auto process_incoming_reply(zpt::stream _stream) const -> zpt::message override;
+    /** @brief Creates a copy of the given message with the transport's protocol and format.
+     * @param _to_copy The message to copy.
+     * @return The copied message. */
+    auto copy(zpt::message const& _to_copy) const -> zpt::message override;
 };
 
 /**
@@ -114,6 +118,10 @@ class file : public zpt::basic_transport {
      * @param _stream Input stream containing the serialized reply.
      * @return Parsed reply message. */
     auto process_incoming_reply(zpt::stream _stream) const -> zpt::message override;
+    /** @brief Creates a copy of the given message with the transport's protocol and format.
+     * @param _to_copy The message to copy.
+     * @return The copied message. */
+    auto copy(zpt::message const& _to_copy) const -> zpt::message override;
 };
 } // namespace transport
 } // namespace net

--- a/network/local/src/file.cpp
+++ b/network/local/src/file.cpp
@@ -60,3 +60,7 @@ auto zpt::net::transport::file::process_incoming_reply(zpt::stream _stream) cons
     (*_stream) >> std::noskipws >> _message;
     return _message;
 }
+
+auto zpt::net::transport::file::copy(zpt::message const& _to_copy) const -> zpt::message {
+    return _to_copy->copy<zpt::json_message>();
+}

--- a/network/local/src/unix.cpp
+++ b/network/local/src/unix.cpp
@@ -62,6 +62,10 @@ auto zpt::net::transport::unix_socket::process_incoming_reply(zpt::stream _strea
     return _message;
 }
 
+auto zpt::net::transport::unix_socket::copy(zpt::message const& _to_copy) const -> zpt::message {
+    return _to_copy->copy<zpt::json_message>();
+}
+
 auto zpt::UNIX_SERVER_SOCKET(std::string const& _path) -> zpt::serversocketstream& {
     static zpt::serversocketstream _global{ "unix", _path };
     return _global;

--- a/network/mqtt/include/zapata/net/transport/mqtt.h
+++ b/network/mqtt/include/zapata/net/transport/mqtt.h
@@ -87,6 +87,10 @@ class mqtt : public zpt::basic_transport {
      * @param _to_publish Message to publish.
      * @return void */
     auto publish(zpt::message _to_publish) const -> void override;
+    /** @brief Creates a copy of the given message with the transport's protocol and format.
+     * @param _to_copy The message to copy.
+     * @return The copied message. */
+    auto copy(zpt::message const& _to_copy) const -> zpt::message override;
 };
 } // namespace transport
 } // namespace net

--- a/network/mqtt/src/mqtt.cpp
+++ b/network/mqtt/src/mqtt.cpp
@@ -65,6 +65,10 @@ auto zpt::net::transport::mqtt::publish(zpt::message _to_publish) const -> void 
     _server->publish(_to_publish);
 }
 
+auto zpt::net::transport::mqtt::copy(zpt::message const& _to_copy) const -> zpt::message {
+    return _to_copy->copy<zpt::json_message>();
+}
+
 auto zpt::MQTT_STREAM(zpt::json _config) -> zpt::mqtt_stream::ptr {
     static auto _global = zpt::allocate_shared<zpt::mqtt_stream>(_config);
     return _global;

--- a/network/pipe/include/zapata/net/transport/pipe.h
+++ b/network/pipe/include/zapata/net/transport/pipe.h
@@ -79,6 +79,10 @@ class pipe_stream : public zpt::basic_transport {
      * @param _stream Input stream containing the serialized reply.
      * @return Parsed reply message. */
     auto process_incoming_reply(zpt::stream _stream) const -> zpt::message override;
+    /** @brief Creates a copy of the given message with the transport's protocol and format.
+     * @param _to_copy The message to copy.
+     * @return The copied message. */
+    auto copy(zpt::message const& _to_copy) const -> zpt::message override;
 };
 } // namespace transport
 } // namespace net

--- a/network/pipe/src/pipe.cpp
+++ b/network/pipe/src/pipe.cpp
@@ -67,3 +67,7 @@ auto zpt::net::transport::pipe_stream::process_incoming_reply(zpt::stream _strea
     (*_stream) >> std::noskipws >> _message;
     return _message;
 }
+
+auto zpt::net::transport::pipe_stream::copy(zpt::message const& _to_copy) const -> zpt::message {
+    return _to_copy->copy<zpt::json_message>();
+}

--- a/network/self/include/zapata/net/transport/self.h
+++ b/network/self/include/zapata/net/transport/self.h
@@ -77,6 +77,10 @@ class self : public zpt::basic_transport {
      * @param _stream Input stream containing the serialized reply.
      * @return Parsed reply message. */
     auto process_incoming_reply(zpt::stream _stream) const -> zpt::message override;
+    /** @brief Creates a copy of the given message with the transport's protocol and format.
+     * @param _to_copy The message to copy.
+     * @return The copied message. */
+    auto copy(zpt::message const& _to_copy) const -> zpt::message override;
 };
 } // namespace transport
 } // namespace net

--- a/network/self/src/self.cpp
+++ b/network/self/src/self.cpp
@@ -60,6 +60,10 @@ auto zpt::net::transport::self::process_incoming_reply(zpt::stream _stream) cons
     return _message;
 }
 
+auto zpt::net::transport::self::copy(zpt::message const& _to_copy) const -> zpt::message {
+    return _to_copy->copy<zpt::json_message>();
+}
+
 auto zpt::CATALOG(std::string const& _name, std::string const& _self_id)
   -> zpt::catalog<std::string, zpt::json>::ptr {
     static auto _global =

--- a/network/tcp/include/zapata/net/transport/tcp.h
+++ b/network/tcp/include/zapata/net/transport/tcp.h
@@ -77,6 +77,10 @@ class tcp : public zpt::basic_transport {
      * @param _stream Input stream containing the serialized reply.
      * @return Parsed reply message. */
     auto process_incoming_reply(zpt::stream _stream) const -> zpt::message override;
+    /** @brief Creates a copy of the given message with the transport's protocol and format.
+     * @param _to_copy The message to copy.
+     * @return The copied message. */
+    auto copy(zpt::message const& _to_copy) const -> zpt::message override;
 };
 } // namespace transport
 } // namespace net

--- a/network/tcp/src/tcp.cpp
+++ b/network/tcp/src/tcp.cpp
@@ -60,6 +60,10 @@ auto zpt::net::transport::tcp::process_incoming_reply(zpt::stream _stream) const
     return _message;
 }
 
+auto zpt::net::transport::tcp::copy(zpt::message const& _to_copy) const -> zpt::message {
+    return _to_copy->copy<zpt::json_message>();
+}
+
 auto zpt::TCP_SERVER_SOCKET(std::string const& _address, std::uint16_t _port)
   -> zpt::serversocketstream& {
     static zpt::serversocketstream _global{ "tcp", _address, _port };

--- a/network/transport/examples/transport.cpp
+++ b/network/transport/examples/transport.cpp
@@ -44,6 +44,10 @@ class some_protocol : public zpt::basic_transport {
         (*_stream) >> _message;
         return _message;
     }
+
+    auto copy(zpt::message const& _to_copy) const -> zpt::message {
+        return _to_copy->clone();
+    }
 };
 
 auto main(int argc, char* argv[]) -> int {

--- a/network/transport/include/zapata/transport/transport.h
+++ b/network/transport/include/zapata/transport/transport.h
@@ -110,13 +110,17 @@ class basic_transport {
      * @return Shared pointer to the new reply message. */
     virtual auto make_reply(zpt::message _request) const -> zpt::message = 0;
     /** @brief Parses an incoming request from a stream.
-     * @param __stream Input stream containing the serialized request.
+     * @param _stream Input stream containing the serialized request.
      * @return Parsed request message. */
     virtual auto process_incoming_request(zpt::stream _stream) const -> zpt::message = 0;
     /** @brief Parses an incoming reply from a stream.
-     * @param __stream Input stream containing the serialized reply.
+     * @param _stream Input stream containing the serialized reply.
      * @return Parsed reply message. */
     virtual auto process_incoming_reply(zpt::stream _stream) const -> zpt::message = 0;
+    /** @brief Creates a copy of the given message with the transport's protocol and format.
+     * @param _to_copy The message to copy.
+     * @return The copied message. */
+    virtual auto copy(zpt::message const& _to_copy) const -> zpt::message = 0;
     /**
      * @brief Retrieves from which transport this was upgraded.
      * @return Reference to the name of the original transport.

--- a/network/upnp/include/zapata/net/transport/upnp.h
+++ b/network/upnp/include/zapata/net/transport/upnp.h
@@ -81,6 +81,10 @@ class upnp : public zpt::basic_transport {
      * @param _stream Input stream containing the serialized reply.
      * @return Parsed reply message. */
     auto process_incoming_reply(zpt::stream _stream) const -> zpt::message override;
+    /** @brief Creates a copy of the given message with the transport's protocol and format.
+     * @param _to_copy The message to copy.
+     * @return The copied message. */
+    auto copy(zpt::message const& _to_copy) const -> zpt::message override;
 };
 } // namespace transport
 } // namespace net

--- a/network/upnp/src/upnp.cpp
+++ b/network/upnp/src/upnp.cpp
@@ -78,3 +78,8 @@ auto zpt::net::transport::upnp::process_incoming_reply(zpt::stream _stream) cons
     (*_stream) >> std::noskipws >> _reply;
     return _reply;
 }
+
+auto zpt::net::transport::upnp::copy(zpt::message const& _to_copy) const -> zpt::message {
+    if (_to_copy->performative() == zpt::Reply) { return _to_copy->copy<zpt::upnp::basic_reply>(); }
+    else { return _to_copy->copy<zpt::upnp::basic_request>(); }
+}

--- a/network/websocket/include/zapata/net/transport/websocket.h
+++ b/network/websocket/include/zapata/net/transport/websocket.h
@@ -122,6 +122,10 @@ class websocket : public zpt::basic_transport {
      * @param _stream Input stream containing the serialized reply.
      * @return Parsed reply message. */
     auto process_incoming_reply(zpt::stream _stream) const -> zpt::message override;
+    /** @brief Creates a copy of the given message with the transport's protocol and format.
+     * @param _to_copy The message to copy.
+     * @return The copied message. */
+    auto copy(zpt::message const& _to_copy) const -> zpt::message override;
 };
 } // namespace transport
 } // namespace net

--- a/network/websocket/src/websocket.cpp
+++ b/network/websocket/src/websocket.cpp
@@ -190,13 +190,22 @@ auto zpt::net::transport::websocket::process_incoming_request(zpt::stream _strea
         return _message;
     }
     catch (::non_json_message const& _e) {
-        auto _message = std::any_cast<zpt::message>(_stream->metadata())->clone();
-        _message->body() = _e.__original;
-        return _message;
+        auto& _any = _stream->metadata();
+        if (_any.has_value()) {
+            auto _message = std::any_cast<zpt::message>(_any)->clone();
+            _message->body() = _e.__original;
+            return _message;
+        }
+        zlog("Unparsable message: " << _e.__original, zpt::error);
+        return nullptr;
     }
 }
 
 auto zpt::net::transport::websocket::process_incoming_reply(zpt::stream _stream) const
   -> zpt::message {
     return this->process_incoming_request(_stream);
+}
+
+auto zpt::net::transport::websocket::copy(zpt::message const& _to_copy) const -> zpt::message {
+    return _to_copy->copy<zpt::ws_message>();
 }


### PR DESCRIPTION
- Adds `basic_message::copy<T>` to translate the target message into the specified template type message.
- Adds `basic_transport::copy` which translates the given message into a message compliant with the given protocol.